### PR TITLE
Dev sidemenu changes

### DIFF
--- a/src/humbug/language/ar/ar_strings.py
+++ b/src/humbug/language/ar/ar_strings.py
@@ -159,6 +159,8 @@ def get_arabic_strings() -> LanguageStrings:
         mindspace_vcs_no_repo="لم يتم العثور على مستودع",
         mindspace_conversations="محادثات",
         mindspace_preview="معاينة",
+        mindspace_expand_sidebar="توسيع الشريط الجانبي",
+        mindspace_collapse_sidebar="طي الشريط الجانبي",
 
         # Mindspace folders dialog
         mindspace_folders_title="تكوين مجلدات المساحة الذهنية",

--- a/src/humbug/language/en/en_strings.py
+++ b/src/humbug/language/en/en_strings.py
@@ -158,6 +158,8 @@ def get_english_strings() -> LanguageStrings:
         mindspace_vcs_no_repo="No repository found",
         mindspace_conversations="Conversations",
         mindspace_preview="Preview",
+        mindspace_expand_sidebar="Expand sidebar",
+        mindspace_collapse_sidebar="Collapse sidebar",
 
         # Mindspace folders dialog
         mindspace_folders_title="Configure Mindspace Folders",

--- a/src/humbug/language/fr/fr_strings.py
+++ b/src/humbug/language/fr/fr_strings.py
@@ -158,6 +158,8 @@ def get_french_strings() -> LanguageStrings:
         mindspace_vcs_no_repo="Aucun dépôt trouvé",
         mindspace_conversations="Conversations",
         mindspace_preview="Aperçu",
+        mindspace_expand_sidebar="Développer la barre latérale",
+        mindspace_collapse_sidebar="Réduire la barre latérale",
 
         # Mindspace folders dialog
         mindspace_folders_title="Configurer les dossiers de l'espace mental",

--- a/src/humbug/language/language_strings.py
+++ b/src/humbug/language/language_strings.py
@@ -149,6 +149,8 @@ class LanguageStrings:
     mindspace_vcs_no_repo: str
     mindspace_conversations: str
     mindspace_preview: str
+    mindspace_expand_sidebar: str
+    mindspace_collapse_sidebar: str
 
     # Mindspace folders dialog
     mindspace_folders_title: str

--- a/src/humbug/mindspace/conversations/mindspace_conversations_view.py
+++ b/src/humbug/mindspace/conversations/mindspace_conversations_view.py
@@ -10,6 +10,7 @@ from PySide6.QtWidgets import (
 )
 
 from humbug.message_box import MessageBox, MessageBoxButton, MessageBoxType
+from humbug.color_role import ColorRole
 from humbug.mindspace.conversations.mindspace_conversations_tree_delegate import MindspaceConversationsTreeDelegate
 from humbug.mindspace.conversations.mindspace_conversations_tree_view import MindspaceConversationsTreeView
 from humbug.mindspace.conversations.mindspace_conversations_dag_model import MindspaceConversationsDAGModel
@@ -57,6 +58,7 @@ class MindspaceConversationsView(QWidget):
             self._language_manager.strings().mindspace_conversations,
             self
         )
+        self._header.set_collapsible(False)
         self._header.toggled.connect(self._on_header_toggled)
         layout.addWidget(self._header)
 
@@ -1179,6 +1181,15 @@ class MindspaceConversationsView(QWidget):
         """Update styling when application style changes."""
         zoom_factor = self._style_manager.zoom_factor()
         base_font_size = self._style_manager.base_font_size()
+        panel_bg = self._style_manager.get_color_str(ColorRole.BACKGROUND_TERTIARY)
+        tree_bg = self._style_manager.get_color_str(ColorRole.MINDSPACE_BACKGROUND)
+        tree_hover = self._style_manager.get_color_str(ColorRole.BACKGROUND_TERTIARY_HOVER)
+        tree_selected = self._style_manager.get_color_str(ColorRole.TEXT_SELECTED)
+        border = self._style_manager.get_color_str(ColorRole.MENU_BORDER)
+        text = self._style_manager.get_color_str(ColorRole.TEXT_PRIMARY)
+        branch_icon_size = round(12 * zoom_factor)
+        collapsed_icon = "arrow-right" if self.layoutDirection() == Qt.LayoutDirection.LeftToRight else "arrow-left"
+        expanded_icon = "arrow-down"
 
         # Apply style to header
         self._header.apply_style()
@@ -1198,3 +1209,42 @@ class MindspaceConversationsView(QWidget):
 
         # Adjust tree indentation
         self._tree_view.setIndentation(file_icon_size)
+        self.setStyleSheet(f"""
+            MindspaceConversationsView {{
+                background-color: {panel_bg};
+            }}
+            MindspaceConversationsTreeView {{
+                background-color: {tree_bg};
+                color: {text};
+                border: 1px solid {border};
+                border-top: none;
+                outline: none;
+            }}
+            MindspaceConversationsTreeView::item {{
+                color: {text};
+                padding: 3px 0px;
+                margin: 0px;
+            }}
+            MindspaceConversationsTreeView::item:hover {{
+                background-color: {tree_hover};
+            }}
+            MindspaceConversationsTreeView::item:selected {{
+                background-color: {tree_selected};
+                color: {text};
+            }}
+            MindspaceConversationsTreeView::branch {{
+                background-color: {tree_bg};
+            }}
+            MindspaceConversationsTreeView::branch:has-children:!has-siblings:closed,
+            MindspaceConversationsTreeView::branch:closed:has-children:has-siblings {{
+                image: url("{self._style_manager.get_icon_path(collapsed_icon)}");
+                width: {branch_icon_size}px;
+                height: {branch_icon_size}px;
+            }}
+            MindspaceConversationsTreeView::branch:open:has-children:!has-siblings,
+            MindspaceConversationsTreeView::branch:open:has-children:has-siblings {{
+                image: url("{self._style_manager.get_icon_path(expanded_icon)}");
+                width: {branch_icon_size}px;
+                height: {branch_icon_size}px;
+            }}
+        """)

--- a/src/humbug/mindspace/conversations/mindspace_conversations_view.py
+++ b/src/humbug/mindspace/conversations/mindspace_conversations_view.py
@@ -10,7 +10,6 @@ from PySide6.QtWidgets import (
 )
 
 from humbug.message_box import MessageBox, MessageBoxButton, MessageBoxType
-from humbug.color_role import ColorRole
 from humbug.mindspace.conversations.mindspace_conversations_tree_delegate import MindspaceConversationsTreeDelegate
 from humbug.mindspace.conversations.mindspace_conversations_tree_view import MindspaceConversationsTreeView
 from humbug.mindspace.conversations.mindspace_conversations_dag_model import MindspaceConversationsDAGModel
@@ -18,6 +17,7 @@ from humbug.mindspace.conversations.mindspace_conversations_index import Mindspa
 from humbug.mindspace.mindspace_collapsible_header import MindspaceCollapsibleHeader
 from humbug.mindspace.mindspace_log_level import MindspaceLogLevel
 from humbug.mindspace.mindspace_manager import MindspaceManager
+from humbug.mindspace.mindspace_pane_style import build_tree_pane_stylesheet
 from humbug.mindspace.mindspace_tree_icon_provider import MindspaceTreeIconProvider
 from humbug.mindspace.mindspace_tree_style import MindspaceTreeStyle
 from humbug.mindspace.mindspace_view_type import MindspaceViewType
@@ -1181,15 +1181,6 @@ class MindspaceConversationsView(QWidget):
         """Update styling when application style changes."""
         zoom_factor = self._style_manager.zoom_factor()
         base_font_size = self._style_manager.base_font_size()
-        panel_bg = self._style_manager.get_color_str(ColorRole.BACKGROUND_TERTIARY)
-        tree_bg = self._style_manager.get_color_str(ColorRole.MINDSPACE_BACKGROUND)
-        tree_hover = self._style_manager.get_color_str(ColorRole.BACKGROUND_TERTIARY_HOVER)
-        tree_selected = self._style_manager.get_color_str(ColorRole.TEXT_SELECTED)
-        border = self._style_manager.get_color_str(ColorRole.MENU_BORDER)
-        text = self._style_manager.get_color_str(ColorRole.TEXT_PRIMARY)
-        branch_icon_size = round(12 * zoom_factor)
-        collapsed_icon = "arrow-right" if self.layoutDirection() == Qt.LayoutDirection.LeftToRight else "arrow-left"
-        expanded_icon = "arrow-down"
 
         # Apply style to header
         self._header.apply_style()
@@ -1209,42 +1200,10 @@ class MindspaceConversationsView(QWidget):
 
         # Adjust tree indentation
         self._tree_view.setIndentation(file_icon_size)
-        self.setStyleSheet(f"""
-            MindspaceConversationsView {{
-                background-color: {panel_bg};
-            }}
-            MindspaceConversationsTreeView {{
-                background-color: {tree_bg};
-                color: {text};
-                border: 1px solid {border};
-                border-top: none;
-                outline: none;
-            }}
-            MindspaceConversationsTreeView::item {{
-                color: {text};
-                padding: 3px 0px;
-                margin: 0px;
-            }}
-            MindspaceConversationsTreeView::item:hover {{
-                background-color: {tree_hover};
-            }}
-            MindspaceConversationsTreeView::item:selected {{
-                background-color: {tree_selected};
-                color: {text};
-            }}
-            MindspaceConversationsTreeView::branch {{
-                background-color: {tree_bg};
-            }}
-            MindspaceConversationsTreeView::branch:has-children:!has-siblings:closed,
-            MindspaceConversationsTreeView::branch:closed:has-children:has-siblings {{
-                image: url("{self._style_manager.get_icon_path(collapsed_icon)}");
-                width: {branch_icon_size}px;
-                height: {branch_icon_size}px;
-            }}
-            MindspaceConversationsTreeView::branch:open:has-children:!has-siblings,
-            MindspaceConversationsTreeView::branch:open:has-children:has-siblings {{
-                image: url("{self._style_manager.get_icon_path(expanded_icon)}");
-                width: {branch_icon_size}px;
-                height: {branch_icon_size}px;
-            }}
-        """)
+        self.setStyleSheet(build_tree_pane_stylesheet(
+            self._style_manager,
+            "MindspaceConversationsView",
+            "MindspaceConversationsTreeView",
+            self.layoutDirection(),
+            zoom_factor,
+        ))

--- a/src/humbug/mindspace/files/mindspace_files_view.py
+++ b/src/humbug/mindspace/files/mindspace_files_view.py
@@ -11,12 +11,12 @@ from PySide6.QtWidgets import (
 )
 
 from humbug.message_box import MessageBox, MessageBoxButton, MessageBoxType
-from humbug.color_role import ColorRole
 from humbug.mindspace.files.mindspace_files_model import MindspaceFilesModel
 from humbug.mindspace.files.mindspace_files_tree_view import MindspaceFilesTreeView
 from humbug.mindspace.mindspace_collapsible_header import MindspaceCollapsibleHeader
 from humbug.mindspace.mindspace_log_level import MindspaceLogLevel
 from humbug.mindspace.mindspace_manager import MindspaceManager
+from humbug.mindspace.mindspace_pane_style import build_tree_pane_stylesheet
 from humbug.mindspace.mindspace_tree_delegate import MindspaceTreeDelegate
 from humbug.mindspace.mindspace_tree_icon_provider import MindspaceTreeIconProvider
 from humbug.mindspace.mindspace_tree_style import MindspaceTreeStyle
@@ -1026,15 +1026,6 @@ class MindspaceFilesView(QWidget):
         """Update styling when application style changes."""
         zoom_factor = self._style_manager.zoom_factor()
         base_font_size = self._style_manager.base_font_size()
-        panel_bg = self._style_manager.get_color_str(ColorRole.BACKGROUND_TERTIARY)
-        tree_bg = self._style_manager.get_color_str(ColorRole.MINDSPACE_BACKGROUND)
-        tree_hover = self._style_manager.get_color_str(ColorRole.BACKGROUND_TERTIARY_HOVER)
-        tree_selected = self._style_manager.get_color_str(ColorRole.TEXT_SELECTED)
-        border = self._style_manager.get_color_str(ColorRole.MENU_BORDER)
-        text = self._style_manager.get_color_str(ColorRole.TEXT_PRIMARY)
-        branch_icon_size = round(12 * zoom_factor)
-        collapsed_icon = "arrow-right" if self.layoutDirection() == Qt.LayoutDirection.LeftToRight else "arrow-left"
-        expanded_icon = "arrow-down"
 
         # Apply style to header
         self._header.apply_style()
@@ -1052,42 +1043,10 @@ class MindspaceFilesView(QWidget):
 
         # Adjust tree indentation
         self._tree_view.setIndentation(file_icon_size)
-        self.setStyleSheet(f"""
-            MindspaceFilesView {{
-                background-color: {panel_bg};
-            }}
-            MindspaceFilesTreeView {{
-                background-color: {tree_bg};
-                color: {text};
-                border: 1px solid {border};
-                border-top: none;
-                outline: none;
-            }}
-            MindspaceFilesTreeView::item {{
-                color: {text};
-                padding: 3px 0px;
-                margin: 0px;
-            }}
-            MindspaceFilesTreeView::item:hover {{
-                background-color: {tree_hover};
-            }}
-            MindspaceFilesTreeView::item:selected {{
-                background-color: {tree_selected};
-                color: {text};
-            }}
-            MindspaceFilesTreeView::branch {{
-                background-color: {tree_bg};
-            }}
-            MindspaceFilesTreeView::branch:has-children:!has-siblings:closed,
-            MindspaceFilesTreeView::branch:closed:has-children:has-siblings {{
-                image: url("{self._style_manager.get_icon_path(collapsed_icon)}");
-                width: {branch_icon_size}px;
-                height: {branch_icon_size}px;
-            }}
-            MindspaceFilesTreeView::branch:open:has-children:!has-siblings,
-            MindspaceFilesTreeView::branch:open:has-children:has-siblings {{
-                image: url("{self._style_manager.get_icon_path(expanded_icon)}");
-                width: {branch_icon_size}px;
-                height: {branch_icon_size}px;
-            }}
-        """)
+        self.setStyleSheet(build_tree_pane_stylesheet(
+            self._style_manager,
+            "MindspaceFilesView",
+            "MindspaceFilesTreeView",
+            self.layoutDirection(),
+            zoom_factor,
+        ))

--- a/src/humbug/mindspace/files/mindspace_files_view.py
+++ b/src/humbug/mindspace/files/mindspace_files_view.py
@@ -11,6 +11,7 @@ from PySide6.QtWidgets import (
 )
 
 from humbug.message_box import MessageBox, MessageBoxButton, MessageBoxType
+from humbug.color_role import ColorRole
 from humbug.mindspace.files.mindspace_files_model import MindspaceFilesModel
 from humbug.mindspace.files.mindspace_files_tree_view import MindspaceFilesTreeView
 from humbug.mindspace.mindspace_collapsible_header import MindspaceCollapsibleHeader
@@ -60,6 +61,7 @@ class MindspaceFilesView(QWidget):
             self
         )
         self._header.setProperty("splitter", True)
+        self._header.set_collapsible(False)
         self._header.toggled.connect(self._on_header_toggled)
         layout.addWidget(self._header)
 
@@ -1024,6 +1026,15 @@ class MindspaceFilesView(QWidget):
         """Update styling when application style changes."""
         zoom_factor = self._style_manager.zoom_factor()
         base_font_size = self._style_manager.base_font_size()
+        panel_bg = self._style_manager.get_color_str(ColorRole.BACKGROUND_TERTIARY)
+        tree_bg = self._style_manager.get_color_str(ColorRole.MINDSPACE_BACKGROUND)
+        tree_hover = self._style_manager.get_color_str(ColorRole.BACKGROUND_TERTIARY_HOVER)
+        tree_selected = self._style_manager.get_color_str(ColorRole.TEXT_SELECTED)
+        border = self._style_manager.get_color_str(ColorRole.MENU_BORDER)
+        text = self._style_manager.get_color_str(ColorRole.TEXT_PRIMARY)
+        branch_icon_size = round(12 * zoom_factor)
+        collapsed_icon = "arrow-right" if self.layoutDirection() == Qt.LayoutDirection.LeftToRight else "arrow-left"
+        expanded_icon = "arrow-down"
 
         # Apply style to header
         self._header.apply_style()
@@ -1041,3 +1052,42 @@ class MindspaceFilesView(QWidget):
 
         # Adjust tree indentation
         self._tree_view.setIndentation(file_icon_size)
+        self.setStyleSheet(f"""
+            MindspaceFilesView {{
+                background-color: {panel_bg};
+            }}
+            MindspaceFilesTreeView {{
+                background-color: {tree_bg};
+                color: {text};
+                border: 1px solid {border};
+                border-top: none;
+                outline: none;
+            }}
+            MindspaceFilesTreeView::item {{
+                color: {text};
+                padding: 3px 0px;
+                margin: 0px;
+            }}
+            MindspaceFilesTreeView::item:hover {{
+                background-color: {tree_hover};
+            }}
+            MindspaceFilesTreeView::item:selected {{
+                background-color: {tree_selected};
+                color: {text};
+            }}
+            MindspaceFilesTreeView::branch {{
+                background-color: {tree_bg};
+            }}
+            MindspaceFilesTreeView::branch:has-children:!has-siblings:closed,
+            MindspaceFilesTreeView::branch:closed:has-children:has-siblings {{
+                image: url("{self._style_manager.get_icon_path(collapsed_icon)}");
+                width: {branch_icon_size}px;
+                height: {branch_icon_size}px;
+            }}
+            MindspaceFilesTreeView::branch:open:has-children:!has-siblings,
+            MindspaceFilesTreeView::branch:open:has-children:has-siblings {{
+                image: url("{self._style_manager.get_icon_path(expanded_icon)}");
+                width: {branch_icon_size}px;
+                height: {branch_icon_size}px;
+            }}
+        """)

--- a/src/humbug/mindspace/mindspace_collapsible_header.py
+++ b/src/humbug/mindspace/mindspace_collapsible_header.py
@@ -4,6 +4,7 @@ from PySide6.QtCore import Signal, Qt, QSize, QEvent
 from PySide6.QtGui import QIcon, QMouseEvent, QEnterEvent
 from PySide6.QtWidgets import QWidget, QHBoxLayout, QLabel, QToolButton
 
+from humbug.color_role import ColorRole
 from humbug.language.language_manager import LanguageManager
 from humbug.style_manager import StyleManager
 
@@ -27,6 +28,7 @@ class MindspaceCollapsibleHeader(QWidget):
         self._style_manager = StyleManager()
         self._language_manager = LanguageManager()
         self._is_expanded = True  # Default to expanded
+        self._is_collapsible = True
 
         # Create layout
         layout = QHBoxLayout(self)
@@ -90,13 +92,29 @@ class MindspaceCollapsibleHeader(QWidget):
         if emit_signal:
             self.toggled.emit(expanded)
 
+    def set_collapsible(self, collapsible: bool) -> None:
+        """Enable or disable expand/collapse interaction for the header."""
+        self._is_collapsible = collapsible
+        self._expand_button.setVisible(collapsible)
+        self.setCursor(
+            Qt.CursorShape.PointingHandCursor if collapsible else Qt.CursorShape.ArrowCursor
+        )
+        self._update_expand_button()
+
     def _toggle_expanded(self) -> None:
         """Toggle the expanded state."""
+        if not self._is_collapsible:
+            return
+
         self.set_expanded(not self._is_expanded)
 
     def _update_expand_button(self) -> None:
         """Update the expand button icon and tooltip based on current state."""
         strings = self._language_manager.strings()
+
+        if not self._is_collapsible:
+            self.setToolTip("")
+            return
 
         if self._is_expanded:
             # Show down arrow when expanded
@@ -134,7 +152,7 @@ class MindspaceCollapsibleHeader(QWidget):
 
     def mousePressEvent(self, event: QMouseEvent) -> None:
         """Handle mouse press events to make entire header clickable."""
-        if event.button() == Qt.MouseButton.LeftButton:
+        if self._is_collapsible and event.button() == Qt.MouseButton.LeftButton:
             self._toggle_expanded()
             event.accept()
             return
@@ -145,11 +163,45 @@ class MindspaceCollapsibleHeader(QWidget):
         """Update styling when application style changes."""
         zoom_factor = self._style_manager.zoom_factor()
         base_font_size = self._style_manager.base_font_size()
+        background = self._style_manager.get_color_str(ColorRole.BACKGROUND_TERTIARY)
+        hover = self._style_manager.get_color_str(ColorRole.BACKGROUND_TERTIARY_HOVER)
+        border = self._style_manager.get_color_str(ColorRole.MENU_BORDER)
+        text = self._style_manager.get_color_str(ColorRole.TEXT_PRIMARY)
+        subtle = self._style_manager.get_color_str(ColorRole.TEXT_INACTIVE)
+        radius = round(8 * zoom_factor)
 
         # Update font size for title label
         font = self.font()
         font.setPointSizeF(base_font_size * zoom_factor)
+        font.setBold(True)
         self._title_label.setFont(font)
 
         # Update expand button
         self._update_expand_button()
+        self.setStyleSheet(f"""
+            QWidget#MindspaceCollapsibleHeader {{
+                background-color: {background};
+                border-top: 1px solid {border};
+                border-bottom: 1px solid {border};
+                border-left: none;
+                border-right: none;
+            }}
+            QWidget#MindspaceCollapsibleHeader[hovered="true"] {{
+                background-color: {hover};
+            }}
+            QWidget#MindspaceCollapsibleHeader QLabel {{
+                color: {text};
+                background: transparent;
+            }}
+            QWidget#MindspaceCollapsibleHeader QToolButton#_expand_button {{
+                color: {subtle};
+                background: transparent;
+                border: none;
+                padding: 0px;
+                margin: 0px;
+                border-radius: {radius}px;
+            }}
+            QWidget#MindspaceCollapsibleHeader QToolButton#_expand_button:hover {{
+                background-color: {hover};
+            }}
+        """)

--- a/src/humbug/mindspace/mindspace_pane_style.py
+++ b/src/humbug/mindspace/mindspace_pane_style.py
@@ -1,0 +1,106 @@
+"""Shared style helpers for mindspace sidebar panes."""
+
+from PySide6.QtCore import Qt
+
+from humbug.color_role import ColorRole
+from humbug.style_manager import StyleManager
+
+
+def build_tree_pane_stylesheet(
+    style_manager: StyleManager,
+    container_selector: str,
+    tree_selector: str,
+    layout_direction: Qt.LayoutDirection,
+    zoom_factor: float,
+) -> str:
+    """Build a stylesheet for a tree-based mindspace pane."""
+    panel_bg = style_manager.get_color_str(ColorRole.BACKGROUND_TERTIARY)
+    tree_bg = style_manager.get_color_str(ColorRole.MINDSPACE_BACKGROUND)
+    tree_hover = style_manager.get_color_str(ColorRole.BACKGROUND_TERTIARY_HOVER)
+    tree_selected = style_manager.get_color_str(ColorRole.TEXT_SELECTED)
+    border = style_manager.get_color_str(ColorRole.MENU_BORDER)
+    text = style_manager.get_color_str(ColorRole.TEXT_PRIMARY)
+    branch_icon_size = round(12 * zoom_factor)
+    collapsed_icon = "arrow-right" if layout_direction == Qt.LayoutDirection.LeftToRight else "arrow-left"
+    expanded_icon = "arrow-down"
+
+    return f"""
+        {container_selector} {{
+            background-color: {panel_bg};
+        }}
+        {tree_selector} {{
+            background-color: {tree_bg};
+            color: {text};
+            border: 1px solid {border};
+            border-top: none;
+            outline: none;
+        }}
+        {tree_selector}::item {{
+            color: {text};
+            padding: 3px 0px;
+            margin: 0px;
+        }}
+        {tree_selector}::item:hover {{
+            background-color: {tree_hover};
+        }}
+        {tree_selector}::item:selected {{
+            background-color: {tree_selected};
+            color: {text};
+        }}
+        {tree_selector}::branch {{
+            background-color: {tree_bg};
+        }}
+        {tree_selector}::branch:has-children:!has-siblings:closed,
+        {tree_selector}::branch:closed:has-children:has-siblings {{
+            image: url("{style_manager.get_icon_path(collapsed_icon)}");
+            width: {branch_icon_size}px;
+            height: {branch_icon_size}px;
+        }}
+        {tree_selector}::branch:open:has-children:!has-siblings,
+        {tree_selector}::branch:open:has-children:has-siblings {{
+            image: url("{style_manager.get_icon_path(expanded_icon)}");
+            width: {branch_icon_size}px;
+            height: {branch_icon_size}px;
+        }}
+    """
+
+
+def build_list_pane_stylesheet(
+    style_manager: StyleManager,
+    container_selector: str,
+    list_selector: str,
+    layout_direction: Qt.LayoutDirection,
+) -> str:
+    """Build a stylesheet for a list-based mindspace pane."""
+    panel_bg = style_manager.get_color_str(ColorRole.BACKGROUND_TERTIARY)
+    list_bg = style_manager.get_color_str(ColorRole.MINDSPACE_BACKGROUND)
+    hover = style_manager.get_color_str(ColorRole.BACKGROUND_TERTIARY_HOVER)
+    selected = style_manager.get_color_str(ColorRole.TEXT_SELECTED)
+    border = style_manager.get_color_str(ColorRole.MENU_BORDER)
+    text = style_manager.get_color_str(ColorRole.TEXT_PRIMARY)
+    padding = "2px 0 0 5px" if layout_direction == Qt.LayoutDirection.LeftToRight else "2px 5px 0 0"
+
+    return f"""
+        {container_selector} {{
+            background-color: {panel_bg};
+        }}
+        {list_selector} {{
+            background-color: {list_bg};
+            color: {text};
+            border: 1px solid {border};
+            border-top: none;
+            outline: none;
+            padding: {padding};
+        }}
+        {list_selector}::item {{
+            color: {text};
+            padding: 2px 0 2px 0;
+            margin: 0px;
+        }}
+        {list_selector}::item:selected {{
+            background-color: {selected};
+        }}
+        {list_selector}::item:hover {{
+            background-color: {hover};
+        }}
+    """

--- a/src/humbug/mindspace/mindspace_view.py
+++ b/src/humbug/mindspace/mindspace_view.py
@@ -2,9 +2,19 @@
 
 import os
 
-from PySide6.QtWidgets import QWidget, QVBoxLayout, QHBoxLayout, QSplitter, QToolButton, QPushButton
-from PySide6.QtCore import Qt, Signal, QSize
+from PySide6.QtCore import QEasingCurve, Qt, QVariantAnimation, Signal, QSize
 from PySide6.QtGui import QIcon
+from PySide6.QtWidgets import (
+    QButtonGroup,
+    QHBoxLayout,
+    QPushButton,
+    QSizePolicy,
+    QSplitter,
+    QStackedWidget,
+    QToolButton,
+    QVBoxLayout,
+    QWidget,
+)
 
 from humbug.color_role import ColorRole
 from humbug.language.language_manager import LanguageManager
@@ -12,25 +22,24 @@ from humbug.mindspace.conversations.mindspace_conversations_view import Mindspac
 from humbug.mindspace.files.mindspace_files_view import MindspaceFilesView
 from humbug.mindspace.mindspace_manager import MindspaceManager
 from humbug.mindspace.mindspace_view_type import MindspaceViewType
-from humbug.mindspace.vcs.mindspace_vcs_view import MindspaceVCSView
 from humbug.mindspace.preview.mindspace_preview_view import MindspacePreviewView
+from humbug.mindspace.vcs.mindspace_vcs_view import MindspaceVCSView
 from humbug.style_manager import StyleManager
 
 
 class MindspaceView(QWidget):
-    """Main mindspace view widget containing files, conversations, and preview sections."""
+    """Main mindspace view widget containing the sidebar rail and active pane."""
 
-    open_mindspace_requested = Signal()  # Emits when user clicks mindspace name
-    # Forward all file-related signals from all views
-    file_clicked = Signal(MindspaceViewType, str, bool)  # Emits view type, path, and ephemeral flag when any file is clicked
-    file_deleted = Signal(str)  # Emits path when file is deleted
-    file_renamed = Signal(str, str)  # Emits (old_path, new_path)
-    file_moved = Signal(str, str)  # Emits (old_path, new_path)
-    file_edited = Signal(str, bool)  # Emits path and ephemeral flag when file is edited
-    file_opened_in_preview = Signal(str, bool)  # Emits path and ephemeral flag when file is opened in preview
-    file_opened_in_diff = Signal(str, bool)  # Emits path and ephemeral flag when file is opened in diff view
-    new_conversation_requested = Signal(str)  # Emits target folder path when user requests new conversation in folder
-    settings_requested = Signal()  # Emits when settings button is clicked
+    open_mindspace_requested = Signal()
+    file_clicked = Signal(MindspaceViewType, str, bool)
+    file_deleted = Signal(str)
+    file_renamed = Signal(str, str)
+    file_moved = Signal(str, str)
+    file_edited = Signal(str, bool)
+    file_opened_in_preview = Signal(str, bool)
+    file_opened_in_diff = Signal(str, bool)
+    new_conversation_requested = Signal(str)
+    settings_requested = Signal()
 
     def __init__(self, parent: QWidget | None = None) -> None:
         """Initialize the mindspace view widget."""
@@ -41,87 +50,102 @@ class MindspaceView(QWidget):
         self._mindspace_manager = MindspaceManager()
         self._language_manager.language_changed.connect(self._on_language_changed)
 
-        # Create main layout
-        layout = QVBoxLayout(self)
+        self._active_view_type = MindspaceViewType.CONVERSATIONS
+        self._vcs_available = False
+        self._sidebar_collapsed = False
+        self._expanded_sidebar_width = 320
+        self._rail_expanded_width = 60
+        self._rail_collapsed_width = 52
+        self._content_min_width = 240
+        self._view_buttons: dict[MindspaceViewType, QToolButton] = {}
+        self._view_widgets: dict[MindspaceViewType, QWidget] = {}
+        self._sidebar_animation = QVariantAnimation(self)
+        self._sidebar_animation.setDuration(160)
+        self._sidebar_animation.setEasingCurve(QEasingCurve.Type.InOutCubic)
+        self._sidebar_animation.valueChanged.connect(self._on_sidebar_animation_value_changed)
+        self._sidebar_animation.finished.connect(self._on_sidebar_animation_finished)
+
+        layout = QHBoxLayout(self)
         layout.setContentsMargins(0, 0, 0, 0)
         layout.setSpacing(0)
 
-        # Create header container for mindspace name
-        self._header_widget = QWidget()
+        self._rail_widget = QWidget(self)
+        self._rail_widget.setObjectName("_rail_widget")
+        rail_layout = QVBoxLayout(self._rail_widget)
+        rail_layout.setContentsMargins(0, 0, 0, 0)
+        rail_layout.setSpacing(0)
+
+        self._view_button_group = QButtonGroup(self)
+        self._view_button_group.setExclusive(True)
+
+        self._sidebar_toggle_button = QToolButton(self._rail_widget)
+        self._sidebar_toggle_button.setObjectName("_sidebar_toggle_button")
+        self._sidebar_toggle_button.setToolButtonStyle(Qt.ToolButtonStyle.ToolButtonIconOnly)
+        self._sidebar_toggle_button.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed)
+        self._sidebar_toggle_button.clicked.connect(self._toggle_sidebar)
+        rail_layout.addWidget(self._sidebar_toggle_button)
+
+        self._conversations_button = self._create_view_button(MindspaceViewType.CONVERSATIONS, "conversation")
+        rail_layout.addWidget(self._conversations_button)
+
+        self._files_button = self._create_view_button(MindspaceViewType.FILES, "files")
+        rail_layout.addWidget(self._files_button)
+
+        self._preview_button = self._create_view_button(MindspaceViewType.PREVIEW, "preview")
+        rail_layout.addWidget(self._preview_button)
+
+        self._vcs_button = self._create_view_button(MindspaceViewType.VCS, "diff")
+        self._vcs_button.hide()
+        rail_layout.addWidget(self._vcs_button)
+
+        rail_layout.addStretch()
+
+        self._settings_button = QToolButton(self._rail_widget)
+        self._settings_button.setObjectName("_settings_button")
+        self._settings_button.setToolButtonStyle(Qt.ToolButtonStyle.ToolButtonIconOnly)
+        self._settings_button.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed)
+        self._settings_button.clicked.connect(self._on_settings_button_clicked)
+        self._settings_button.hide()
+        rail_layout.addWidget(self._settings_button)
+
+        layout.addWidget(self._rail_widget)
+
+        self._content_widget = QWidget(self)
+        self._content_widget.setObjectName("_content_widget")
+        content_layout = QVBoxLayout(self._content_widget)
+        content_layout.setContentsMargins(0, 0, 0, 0)
+        content_layout.setSpacing(0)
+
+        self._header_widget = QWidget(self._content_widget)
         self._header_widget.setObjectName("_header_widget")
         header_layout = QHBoxLayout(self._header_widget)
-        header_layout.setContentsMargins(8, 6, 8, 6)
-        header_layout.setSpacing(0)
+        header_layout.setContentsMargins(14, 10, 10, 10)
+        header_layout.setSpacing(8)
 
-        # Create mindspace name button
-        self._mindspace_button = QPushButton()
+        self._mindspace_button = QPushButton(self._header_widget)
         self._mindspace_button.setObjectName("_mindspace_button")
         self._mindspace_button.clicked.connect(self.open_mindspace_requested.emit)
-
         header_layout.addWidget(self._mindspace_button)
         header_layout.addStretch()
 
-        # Create settings button (initially hidden)
-        self._settings_button = QToolButton(self._header_widget)
-        self._settings_button.setObjectName("_settings_button")
-        self._settings_button.clicked.connect(self._on_settings_button_clicked)
-        self._settings_button.hide()
-        header_layout.addWidget(self._settings_button)
+        content_layout.addWidget(self._header_widget)
 
-        layout.addWidget(self._header_widget)
+        self._pane_stack = QStackedWidget(self._content_widget)
+        self._pane_stack.setObjectName("_pane_stack")
+        content_layout.addWidget(self._pane_stack)
 
-        # Create splitter for mindspace views
-        self._splitter = QSplitter(Qt.Orientation.Vertical)
-        layout.addWidget(self._splitter)
+        layout.addWidget(self._content_widget, 1)
 
-        # Add conversations view
         self._conversations_view = MindspaceConversationsView()
-        self._splitter.addWidget(self._conversations_view)
-
-        # Add VCS view (between conversations and files)
-        self._vcs_view = MindspaceVCSView()
-        self._splitter.addWidget(self._vcs_view)
-
-        # Add files view
         self._files_view = MindspaceFilesView()
-        self._splitter.addWidget(self._files_view)
-
-        # Add preview view (starts collapsed)
         self._preview_view = MindspacePreviewView()
-        self._splitter.addWidget(self._preview_view)
+        self._vcs_view = MindspaceVCSView()
 
-        # Create spacer widget - invisible widget that takes up space when all sections are collapsed
-        self._spacer_widget = QWidget()
-        self._spacer_widget.setObjectName("_spacer_widget")
-        self._splitter.addWidget(self._spacer_widget)
+        self._register_view(MindspaceViewType.CONVERSATIONS, self._conversations_view)
+        self._register_view(MindspaceViewType.FILES, self._files_view)
+        self._register_view(MindspaceViewType.PREVIEW, self._preview_view)
+        self._register_view(MindspaceViewType.VCS, self._vcs_view)
 
-        # Set initial proportions: equal for conversations and files, 0 for preview and spacer
-        self._splitter.setSizes([1, 1, 1, 0, 0])
-
-        # Set stretch factors - all sections and spacer can stretch
-        self._splitter.setStretchFactor(0, 1)  # Conversations
-        self._splitter.setStretchFactor(1, 1)  # VCS
-        self._splitter.setStretchFactor(2, 1)  # Files
-        self._splitter.setStretchFactor(3, 1)  # Preview
-        self._splitter.setStretchFactor(4, 1)  # Spacer
-
-        # Prevent complete collapse by making sections non-collapsible
-        self._splitter.setCollapsible(0, False)  # Conversations view cannot be collapsed
-        self._splitter.setCollapsible(1, False)  # VCS view cannot be collapsed
-        self._splitter.setCollapsible(2, False)  # Files view cannot be collapsed
-        self._splitter.setCollapsible(3, False)  # Preview view cannot be collapsed
-        self._splitter.setCollapsible(4, True)   # Spacer widget can be collapsed
-
-        # Set minimum sizes to ensure headers remain visible
-        self._update_minimum_sizes()
-
-        # Connect header toggle signals to manage splitter sizes
-        self._conversations_view.toggled.connect(self._on_conversations_toggled)
-        self._vcs_view.toggled.connect(self._on_vcs_toggled)
-        self._files_view.toggled.connect(self._on_files_toggled)
-        self._preview_view.toggled.connect(self._on_preview_toggled)
-
-        # Connect files view signals - files view clicks go to editor
         self._files_view.file_clicked.connect(self.file_clicked.emit)
         self._files_view.file_deleted.connect(self.file_deleted.emit)
         self._files_view.file_renamed.connect(self.file_renamed.emit)
@@ -130,7 +154,6 @@ class MindspaceView(QWidget):
         self._files_view.file_opened_in_preview.connect(self.file_opened_in_preview.emit)
         self._files_view.file_opened_in_diff.connect(self.file_opened_in_diff.emit)
 
-        # Connect conversations view signals - conversations view clicks go to editor
         self._conversations_view.file_clicked.connect(self.file_clicked.emit)
         self._conversations_view.file_deleted.connect(self.file_deleted.emit)
         self._conversations_view.file_renamed.connect(self.file_renamed.emit)
@@ -139,7 +162,6 @@ class MindspaceView(QWidget):
         self._conversations_view.file_opened_in_preview.connect(self.file_opened_in_preview.emit)
         self._conversations_view.new_conversation_requested.connect(self.new_conversation_requested.emit)
 
-        # Connect VCS view signals
         self._vcs_view.file_opened_in_diff.connect(self.file_opened_in_diff.emit)
         self._vcs_view.file_clicked.connect(self.file_clicked.emit)
         self._vcs_view.file_deleted.connect(self.file_deleted.emit)
@@ -147,7 +169,6 @@ class MindspaceView(QWidget):
         self._vcs_view.file_opened_in_preview.connect(self.file_opened_in_preview.emit)
         self._vcs_view.repo_available.connect(self._on_vcs_repo_available)
 
-        # Connect preview view signals - preview view clicks go to preview
         self._preview_view.file_clicked.connect(self.file_clicked.emit)
         self._preview_view.file_deleted.connect(self.file_deleted.emit)
         self._preview_view.file_renamed.connect(self.file_renamed.emit)
@@ -155,179 +176,149 @@ class MindspaceView(QWidget):
         self._preview_view.file_edited.connect(self.file_edited.emit)
         self._preview_view.file_opened_in_preview.connect(self.file_opened_in_preview.emit)
 
-        # Set initial label text
         self._mindspace_button.setText(self._language_manager.strings().mindspace_label_none)
-
+        self._set_active_view(MindspaceViewType.CONVERSATIONS)
         self._on_language_changed()
 
-    def _update_minimum_sizes(self) -> None:
-        """Update minimum sizes for splitter widgets to ensure headers remain visible."""
-        # Calculate minimum height needed to show just the header
-        conversations_header_height = self._conversations_view.get_header_height()
-        conversations_expanded = self._conversations_view.is_expanded()
-        vcs_visible = self._vcs_view.isVisible()
-        vcs_header_height = self._vcs_view.get_header_height() if vcs_visible else 0
-        vcs_expanded = self._vcs_view.is_expanded() if vcs_visible else False
-        files_header_height = self._files_view.get_header_height()
-        files_expanded = self._files_view.is_expanded()
-        preview_header_height = self._preview_view.get_header_height()
-        preview_expanded = self._preview_view.is_expanded()
+    def _create_view_button(self, view_type: MindspaceViewType, icon_name: str) -> QToolButton:
+        """Create a left-rail button for a view."""
+        button = QToolButton(self._rail_widget)
+        button.setObjectName(f"_view_button_{view_type.name.lower()}")
+        button.setProperty("view_type", view_type.name.lower())
+        button.setProperty("icon_name", icon_name)
+        button.setCheckable(True)
+        button.setAutoRaise(False)
+        button.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed)
+        button.clicked.connect(lambda checked, vt=view_type: self._on_view_button_clicked(vt, checked))
+        self._view_button_group.addButton(button)
+        self._view_buttons[view_type] = button
+        return button
 
-        # Set minimum size for each view to their header height
-        # This prevents them from being collapsed completely
-        if conversations_expanded:
-            self._conversations_view.setMinimumHeight(
-                conversations_header_height + (conversations_header_height * 2 if conversations_expanded else 0)
-            )
-            self._conversations_view.setMaximumHeight(16777215)
+    def _register_view(self, view_type: MindspaceViewType, view: QWidget) -> None:
+        """Register a view in the stacked content area."""
+        self._view_widgets[view_type] = view
+        self._pane_stack.addWidget(view)
 
-        else:
-            self._conversations_view.setFixedHeight(conversations_header_height)
+    def _on_view_button_clicked(self, view_type: MindspaceViewType, checked: bool) -> None:
+        """Switch active pane from rail selection."""
+        if checked:
+            self._set_active_view(view_type)
 
-        if vcs_visible:
-            if vcs_expanded:
-                self._vcs_view.setMinimumHeight(vcs_header_height * 3)
-                self._vcs_view.setMaximumHeight(16777215)
-            else:
-                self._vcs_view.setFixedHeight(vcs_header_height)
-        else:
-            self._vcs_view.setFixedHeight(0)
+    def _set_active_view(self, view_type: MindspaceViewType) -> None:
+        """Set the active view in the stacked pane."""
+        if view_type == MindspaceViewType.VCS and not self._vcs_available:
+            view_type = MindspaceViewType.CONVERSATIONS
 
-        if files_expanded:
-            self._files_view.setMinimumHeight(
-                files_header_height + (files_header_height * 2 if files_expanded else 0)
-            )
-            self._files_view.setMaximumHeight(16777215)
+        widget = self._view_widgets[view_type]
+        self._pane_stack.setCurrentWidget(widget)
+        self._active_view_type = view_type
 
-        else:
-            self._files_view.setFixedHeight(files_header_height)
+        button = self._view_buttons[view_type]
+        if not button.isChecked():
+            button.setChecked(True)
 
-        if preview_expanded:
-            self._preview_view.setMinimumHeight(
-                preview_header_height + (preview_header_height * 2 if preview_expanded else 0)
-            )
-            self._preview_view.setMaximumHeight(16777215)
+        self._update_button_styling()
 
-        else:
-            self._preview_view.setFixedHeight(preview_header_height)
+    def _toggle_sidebar(self) -> None:
+        """Toggle the mindspace sidebar between expanded and collapsed states."""
+        self._set_sidebar_collapsed(not self._sidebar_collapsed, animated=True)
 
-        # The spacer widget can be collapsed to 0
-        self._spacer_widget.setMinimumHeight(0)
-
-    def _on_conversations_toggled(self, _expanded: bool) -> None:
-        """
-        Handle conversations section expand/collapse.
-
-        Args:
-            expanded: Whether the conversations section is now expanded
-        """
-        self._update_splitter_sizes()
-
-    def _on_vcs_toggled(self, _expanded: bool) -> None:
-        """
-        Handle VCS section expand/collapse.
-
-        Args:
-            _expanded: Whether the VCS section is now expanded
-        """
-        self._update_splitter_sizes()
-
-    def _on_vcs_repo_available(self, _has_repo: bool) -> None:
-        """
-        Handle the VCS view appearing or disappearing as a repo is detected.
-
-        Args:
-            _has_repo: Whether a repository is now present.
-        """
-        self._update_splitter_sizes()
-
-    def _on_files_toggled(self, _expanded: bool) -> None:
-        """
-        Handle files section expand/collapse.
-
-        Args:
-            expanded: Whether the files section is now expanded
-        """
-        self._update_splitter_sizes()
-
-    def _on_preview_toggled(self, _expanded: bool) -> None:
-        """
-        Handle preview section expand/collapse.
-
-        Args:
-            expanded: Whether the preview section is now expanded
-        """
-        self._update_splitter_sizes()
-
-    def _update_splitter_sizes(self) -> None:
-        """Update splitter sizes based on current expansion states."""
-        self._update_minimum_sizes()
-
-        conversations_expanded = self._conversations_view.is_expanded()
-        vcs_visible = self._vcs_view.isVisible()
-        vcs_expanded = self._vcs_view.is_expanded() if vcs_visible else False
-        files_expanded = self._files_view.is_expanded()
-        preview_expanded = self._preview_view.is_expanded()
-
-        # Get current splitter height
-        total_height = self._splitter.height()
-        if total_height <= 0:
-            # Splitter not yet sized, use default proportions
-            total_height = 600
-
-        # Calculate header height based on zoom factor
-        header_height = self._conversations_view.get_header_height()
-
-        # Count expanded sections
-        expanded_sections = sum([conversations_expanded, vcs_expanded, files_expanded, preview_expanded])
-        visible_collapsed = sum([
-            not conversations_expanded,
-            vcs_visible and not vcs_expanded,
-            not files_expanded,
-            not preview_expanded,
-        ])
-
-        if expanded_sections == 0:
-            # Give minimal space to all sections, all remaining space to spacer
-            spacer_size = total_height - (visible_collapsed * header_height)
-            vcs_size = header_height if vcs_visible else 0
-            self._splitter.setSizes([header_height, vcs_size, header_height, header_height, spacer_size])
+    def _set_sidebar_collapsed(self, collapsed: bool, animated: bool) -> None:
+        """Collapse or expand the sidebar."""
+        if self._sidebar_collapsed == collapsed and not self._sidebar_animation.state():
             return
 
-        # We have one or more expanded sections - distribute space evenly among them
-        available_space = total_height - (visible_collapsed * header_height)
-        section_space = available_space // expanded_sections
+        current_width = max(self.width(), self._rail_expanded_width + 1)
+        expanded_width = max(self._expanded_sidebar_width, self._rail_expanded_width + self._content_min_width)
+        target_width = self._rail_collapsed_width if collapsed else expanded_width
 
-        conversations_space = section_space if conversations_expanded else header_height
-        vcs_space = (section_space if vcs_expanded else header_height) if vcs_visible else 0
-        files_space = section_space if files_expanded else header_height
-        preview_space = section_space if preview_expanded else header_height
+        if collapsed:
+            self._expanded_sidebar_width = max(current_width, expanded_width)
+        else:
+            self._content_widget.show()
 
-        self._splitter.setSizes([conversations_space, vcs_space, files_space, preview_space, 0])
+        self._sidebar_collapsed = collapsed
+        self._update_button_styling()
+        self.apply_style()
+
+        if animated:
+            self._sidebar_animation.stop()
+            self._sidebar_animation.setStartValue(current_width)
+            self._sidebar_animation.setEndValue(target_width)
+            self._sidebar_animation.start()
+        else:
+            self._apply_sidebar_width(target_width)
+            self._on_sidebar_animation_finished()
+
+    def _on_sidebar_animation_value_changed(self, value: object) -> None:
+        """Apply animated sidebar width changes."""
+        self._apply_sidebar_width(int(value))
+
+    def _on_sidebar_animation_finished(self) -> None:
+        """Finalize sidebar state after animation."""
+        if self._sidebar_collapsed:
+            self._content_widget.hide()
+            self.setFixedWidth(self._rail_collapsed_width)
+        else:
+            self._content_widget.show()
+            self.setMinimumWidth(self._rail_expanded_width + self._content_min_width)
+            self.setMaximumWidth(16777215)
+
+    def _apply_sidebar_width(self, width: int) -> None:
+        """Apply a sidebar width and redistribute splitter space if needed."""
+        width = max(self._rail_collapsed_width, width)
+        self.setMinimumWidth(width)
+        self.setMaximumWidth(width)
+        self.resize(width, self.height())
+
+        parent = self.parentWidget()
+        if isinstance(parent, QSplitter):
+            index = parent.indexOf(self)
+            if index >= 0:
+                sizes = parent.sizes()
+                if index < len(sizes):
+                    delta = width - sizes[index]
+                    sizes[index] = width
+                    for i in range(len(sizes) - 1, -1, -1):
+                        if i == index:
+                            continue
+                        sizes[i] = max(1, sizes[i] - delta)
+                        break
+                    parent.setSizes(sizes)
+
+    def _on_vcs_repo_available(self, has_repo: bool) -> None:
+        """Show or hide the VCS rail button when repository state changes."""
+        self._vcs_available = has_repo
+        self._vcs_button.setVisible(has_repo)
+
+        if not has_repo and self._active_view_type == MindspaceViewType.VCS:
+            self._set_active_view(MindspaceViewType.CONVERSATIONS)
+        else:
+            self._update_button_styling()
 
     def reveal_and_select_file(self, view_type: MindspaceViewType, file_path: str) -> None:
         """
-        Reveal and select a file in the appropriate view (files, conversations, or preview).
+        Reveal and select a file in the appropriate view.
 
         Args:
             file_path: Absolute path to the file to reveal and select
         """
-        if not file_path:
-            return
-
-        # Use mindspace manager to properly determine if file is in conversations hierarchy
-        if not self._mindspace_manager.has_mindspace():
+        if not file_path or not self._mindspace_manager.has_mindspace():
             return
 
         match view_type:
             case MindspaceViewType.CONVERSATIONS:
+                self._set_active_view(MindspaceViewType.CONVERSATIONS)
                 self._conversations_view.reveal_and_select_file(file_path)
-
             case MindspaceViewType.FILES:
+                self._set_active_view(MindspaceViewType.FILES)
                 self._files_view.reveal_and_select_file(file_path)
-
             case MindspaceViewType.PREVIEW:
+                self._set_active_view(MindspaceViewType.PREVIEW)
                 self._preview_view.reveal_and_select_file(file_path)
+            case MindspaceViewType.VCS:
+                if self._vcs_available:
+                    self._set_active_view(MindspaceViewType.VCS)
 
     def set_mindspace(self, path: str) -> None:
         """
@@ -336,16 +327,13 @@ class MindspaceView(QWidget):
         Args:
             path: Path to the mindspace directory, or empty string to clear
         """
-        # Update the mindspace label
         if not path:
             self._mindspace_button.setText(self._language_manager.strings().mindspace_label_none)
             self._settings_button.hide()
-
         else:
-            self._mindspace_button.setText(os.path.basename(path.rstrip('\\/')))
+            self._mindspace_button.setText(os.path.basename(path.rstrip("\\/")))
             self._settings_button.show()
 
-        # Forward to all views
         self._files_view.set_mindspace(path)
         self._conversations_view.set_mindspace(path)
         self._vcs_view.set_mindspace(path)
@@ -357,232 +345,209 @@ class MindspaceView(QWidget):
 
     def _on_language_changed(self) -> None:
         """Update when the language changes."""
-        # Update mindspace label if no mindspace is active
         current_text = self._mindspace_button.text()
         none_text = self._language_manager.strings().mindspace_label_none
         if current_text == none_text or not current_text:
             self._mindspace_button.setText(none_text)
 
-        # Update button tooltip
-        self._mindspace_button.setToolTip(self._language_manager.strings().mindspace_name_tooltip)
-
-        # Update settings button tooltip
-        self._settings_button.setToolTip(self._language_manager.strings().mindspace_settings)
+        strings = self._language_manager.strings()
+        self._mindspace_button.setToolTip(strings.mindspace_name_tooltip)
+        self._settings_button.setToolTip(strings.mindspace_settings)
+        self._conversations_button.setToolTip(strings.mindspace_conversations)
+        self._files_button.setToolTip(strings.mindspace_files)
+        self._preview_button.setToolTip(strings.mindspace_preview)
+        self._vcs_button.setToolTip(strings.mindspace_vcs)
+        self._sidebar_toggle_button.setToolTip(
+            strings.mindspace_collapse_sidebar if not self._sidebar_collapsed else strings.mindspace_expand_sidebar
+        )
 
         self.apply_style()
 
     def _update_button_styling(self) -> None:
-        """Update button styling and icons."""
-        # Apply icon and styling
-        icon_base_size = 14
-        icon_scaled_size = int(icon_base_size * self._style_manager.zoom_factor())
-        icon_size = QSize(icon_scaled_size, icon_scaled_size)
+        """Update button icons and sizes."""
+        zoom_factor = self._style_manager.zoom_factor()
+        icon_base_size = 18
+        icon_size = QSize(round(icon_base_size * zoom_factor), round(icon_base_size * zoom_factor))
 
-        # Update settings button
-        self._settings_button.setIcon(QIcon(self._style_manager.scale_icon("cog", icon_base_size)))
-        self._settings_button.setIconSize(icon_size)
+        if self.layoutDirection() == Qt.LayoutDirection.LeftToRight:
+            collapse_icon = "expand-right" if self._sidebar_collapsed else "expand-left"
+        else:
+            collapse_icon = "expand-left" if self._sidebar_collapsed else "expand-right"
+
+        self._sidebar_toggle_button.setIcon(QIcon(self._style_manager.scale_icon(collapse_icon, 16)))
+        self._sidebar_toggle_button.setIconSize(QSize(round(16 * zoom_factor), round(16 * zoom_factor)))
+
+        for view_type, button in self._view_buttons.items():
+            icon_name = button.property("icon_name")
+            assert isinstance(icon_name, str)
+
+            if button.isChecked():
+                pixmap = self._style_manager.scale_icon(icon_name, icon_base_size)
+            else:
+                pixmap = self._style_manager.scale_icon(f"inactive-{icon_name}", icon_base_size)
+
+            button.setIcon(QIcon(pixmap))
+            button.setIconSize(icon_size)
+            button.setChecked(view_type == self._active_view_type)
+
+        self._settings_button.setIcon(QIcon(self._style_manager.scale_icon("cog", 16)))
+        self._settings_button.setIconSize(QSize(round(16 * zoom_factor), round(16 * zoom_factor)))
 
     def apply_style(self) -> None:
         """Update styling when application style changes."""
         zoom_factor = self._style_manager.zoom_factor()
         base_font_size = self._style_manager.base_font_size()
 
-        # Update font size for mindspace label
-        font = self._mindspace_button.font()
-        font.setPointSize(int(base_font_size * zoom_factor))
-        self._mindspace_button.setFont(font)
+        self._rail_expanded_width = round(60 * zoom_factor)
+        self._rail_collapsed_width = round(52 * zoom_factor)
+        self._content_min_width = round(230 * zoom_factor)
 
-        # Update button styling
+        header_font = self._mindspace_button.font()
+        header_font.setPointSizeF(base_font_size * zoom_factor)
+        header_font.setBold(True)
+        self._mindspace_button.setFont(header_font)
+
+        rail_button_font = self.font()
+        rail_button_font.setPointSizeF(base_font_size * zoom_factor)
+        self.setFont(rail_button_font)
+
         self._update_button_styling()
 
-        branch_icon_size = round(12 * zoom_factor)
+        rail_width = self._rail_collapsed_width if self._sidebar_collapsed else self._rail_expanded_width
+        rail_button_height = round(48 * zoom_factor)
+        toggle_button_height = round(40 * zoom_factor)
+        rail_padding = round(8 * zoom_factor)
+        rail_indicator = round(3 * zoom_factor)
+        content_radius = round(8 * zoom_factor)
+        header_bottom_border = self._style_manager.get_color_str(ColorRole.MENU_BORDER)
+        panel_background = self._style_manager.get_color_str(ColorRole.MINDSPACE_BACKGROUND)
+        rail_background = self._style_manager.get_color_str(ColorRole.BACKGROUND_SECONDARY)
+        rail_hover = self._style_manager.get_color_str(ColorRole.BACKGROUND_TERTIARY_HOVER)
+        selected_background = self._style_manager.get_color_str(ColorRole.BACKGROUND_TERTIARY)
+        header_background = self._style_manager.get_color_str(ColorRole.BACKGROUND_TERTIARY)
+        header_hover = self._style_manager.get_color_str(ColorRole.MINDSPACE_NAME_BACKGROUND_HOVER)
+        header_pressed = self._style_manager.get_color_str(ColorRole.MINDSPACE_NAME_BACKGROUND_PRESSED)
+        text_color = self._style_manager.get_color_str(ColorRole.TEXT_PRIMARY)
+        disabled_color = self._style_manager.get_color_str(ColorRole.TEXT_DISABLED)
+        subtle_text = self._style_manager.get_color_str(ColorRole.TEXT_INACTIVE)
+        border_color = self._style_manager.get_color_str(ColorRole.MENU_BORDER)
+        accent_color = self._style_manager.get_color_str(ColorRole.TAB_BORDER_ACTIVE)
+        content_surface = self._style_manager.get_color_str(ColorRole.BACKGROUND_TERTIARY)
 
-        # Deal with a few layout direction specifics.  We really shouldn't need to adjust the padding here, but
-        # the layout engine seems to be having trouble with it in RTL mode.
-        if self.layoutDirection() == Qt.LayoutDirection.LeftToRight:
-            expand_icon = "arrow-right"
-            tree_left_padding = 0
-            tree_right_padding = 8
+        indicator_side = "border-left" if self.layoutDirection() == Qt.LayoutDirection.LeftToRight else "border-right"
 
-        else:
-            expand_icon = "arrow-left"
-            tree_left_padding = 8
-            tree_right_padding = 0
+        self._rail_widget.setFixedWidth(rail_width)
+        self._sidebar_toggle_button.setFixedHeight(toggle_button_height)
+        for button in self._view_buttons.values():
+            button.setFixedHeight(rail_button_height)
+        self._settings_button.setFixedHeight(rail_button_height)
+        self._content_widget.setMinimumWidth(0 if self._sidebar_collapsed else self._content_min_width)
 
-        background_color = self._style_manager.get_color_str(ColorRole.MINDSPACE_NAME_BACKGROUND)
-
-        # Style the mindspace view
         self.setStyleSheet(f"""
             {self._style_manager.get_menu_stylesheet()}
-
-            #_header_widget {{
-                background-color: {self._style_manager.get_color_str(ColorRole.MINDSPACE_NAME_BACKGROUND)};
-                margin: 0px;
-                padding: 0px;
-                border: none;
-            }}
-
-            #_header_widget #_settings_button {{
-                background-color: {background_color};
-                color: {self._style_manager.get_color_str(ColorRole.TEXT_PRIMARY)};
-                border: none;
-                padding: 0px;
-            }}
-            #_header_widget #_settings_button:hover {{
-                background-color: {self._style_manager.get_color_str(ColorRole.MINDSPACE_NAME_BACKGROUND_HOVER)};
-            }}
-            #_header_widget #_settings_button:pressed {{
-                background-color: {self._style_manager.get_color_str(ColorRole.MINDSPACE_NAME_BACKGROUND_PRESSED)};
-            }}
-            #_header_widget #_settings_button:disabled {{
-                color: {self._style_manager.get_color_str(ColorRole.TEXT_DISABLED)};
-                background-color: {background_color};
-            }}
-
-            #_header_widget #_mindspace_button {{
-                color: {self._style_manager.get_color_str(ColorRole.TEXT_PRIMARY)};
-                background-color: transparent;
-                border: none;
-                margin: 0px;
-                padding: 1px 3px 1px 3px;
-            }}
-            #_header_widget #_mindspace_button:hover {{
-                background-color: {self._style_manager.get_color_str(ColorRole.MINDSPACE_NAME_BACKGROUND_HOVER)};
-            }}
-            #_header_widget #_mindspace_button:pressed {{
-                background-color: {self._style_manager.get_color_str(ColorRole.MINDSPACE_NAME_BACKGROUND_PRESSED)};
-            }}
-            #_header_widget #_mindspace_button:disabled {{
-                color: {self._style_manager.get_color_str(ColorRole.TEXT_DISABLED)};
-                background-color: transparent;
-            }}
-
-            #MindspaceCollapsibleHeader {{
-                background-color: {self._style_manager.get_color_str(ColorRole.MINDSPACE_HEADING)};
-                border-radius: 0px;
-                margin: 0px;
-                padding: 0px 0px 1px 0px;
-            }}
-            #MindspaceCollapsibleHeader[splitter="true"] {{
-                border-top: 1px solid {self._style_manager.get_color_str(ColorRole.SPLITTER)};
-            }}
-            #MindspaceCollapsibleHeader[hovered="true"] {{
-                background-color: {self._style_manager.get_color_str(ColorRole.TAB_BACKGROUND_HOVER)};
-            }}
-
-            #MindspaceCollapsibleHeader QLabel {{
-                color: {self._style_manager.get_color_str(ColorRole.TEXT_PRIMARY)};
-                background-color: transparent;
-                border: none;
-                padding: 0px;
-                margin: 0px;
-            }}
-
-            #MindspaceCollapsibleHeader QToolButton#_expand_button {{
-                background-color: transparent;
-                border: none;
-                padding: 0px 0px 0px 2px;
-                margin: 0px;
-            }}
-
-            QWidget#_spacer_widget {{
-                background-color: {self._style_manager.get_color_str(ColorRole.MINDSPACE_BACKGROUND)};
-                border-top: 1px solid {self._style_manager.get_color_str(ColorRole.SPLITTER)};
-            }}
-
-            QSplitter::handle {{
-                background-color: {self._style_manager.get_color_str(ColorRole.SPLITTER)};
-                margin: 0;
-                height: 0px;
-            }}
-
-            QTreeView {{
-                background-color: {self._style_manager.get_color_str(ColorRole.MINDSPACE_BACKGROUND)};
-                border: none;
-                padding: 0 {tree_left_padding}px 0 {tree_right_padding}px;
-            }}
-            QTreeView::item {{
-                color: {self._style_manager.get_color_str(ColorRole.TEXT_PRIMARY)};
-                padding: 2px 0 2px 0;
-                margin: 0px;
-            }}
-            QTreeView::item:selected {{
-                background-color: {self._style_manager.get_color_str(ColorRole.TEXT_SELECTED)};
-            }}
-            QTreeView::item:hover {{
-                background-color: {self._style_manager.get_color_str(ColorRole.TAB_BACKGROUND_HOVER)};
-            }}
-            QTreeView::branch {{
-                background-color: {self._style_manager.get_color_str(ColorRole.MINDSPACE_BACKGROUND)};
-            }}
-            QTreeView::branch:has-children:!has-siblings:closed,
-            QTreeView::branch:closed:has-children:has-siblings {{
-                image: url("{self._style_manager.get_icon_path(expand_icon)}");
-                padding: 0px;
-                width: {branch_icon_size}px;
-                height: {branch_icon_size}px;
-            }}
-            QTreeView::branch:open:has-children:!has-siblings,
-            QTreeView::branch:open:has-children:has-siblings {{
-                image: url("{self._style_manager.get_icon_path("arrow-down")}");
-                padding: 0px;
-                width: {branch_icon_size}px;
-                height: {branch_icon_size}px;
-            }}
-
-            MindspaceRootDropWidget {{
-                background-color: {self._style_manager.get_color_str(ColorRole.MINDSPACE_BACKGROUND)};
-                border: none;
-            }}
-            MindspaceRootDropWidget[is_drop_target="true"] {{
-                background-color: {self._style_manager.get_color_str(ColorRole.BUTTON_BACKGROUND_HOVER)};
-                border: 1px solid {self._style_manager.get_color_str(ColorRole.TEXT_SELECTED)};
-            }}
-
             {self._style_manager.get_scrollbar_stylesheet()}
 
-            QToolTip {{
-                background-color: {self._style_manager.get_color_str(ColorRole.BUTTON_BACKGROUND_HOVER)};
-                color: {self._style_manager.get_color_str(ColorRole.TEXT_PRIMARY)};
-                padding: 1px;
+            MindspaceView {{
+                background-color: {panel_background};
+            }}
+
+            QWidget#_rail_widget {{
+                background-color: {rail_background};
+                border-right: 1px solid {border_color};
+            }}
+
+            QWidget#_content_widget {{
+                background-color: {panel_background};
+                border-right: 1px solid {border_color};
+            }}
+
+            QWidget#_header_widget {{
+                background-color: {header_background};
+                border-bottom: 1px solid {header_bottom_border};
+            }}
+
+            QWidget#_pane_stack {{
+                background-color: {panel_background};
+                border: none;
+            }}
+
+            QPushButton#_mindspace_button {{
+                color: {text_color};
+                background-color: transparent;
+                border: none;
                 margin: 0px;
-                border: 1px solid {self._style_manager.get_color_str(ColorRole.TEXT_DISABLED)};
+                padding: 4px 6px;
+                text-align: left;
             }}
 
-            QMenu::right-arrow {{
-                image: url({self._style_manager.get_icon_path('arrow-right')});
-                width: 16px;
-                height: 16px;
-            }}
-            QMenu::left-arrow {{
-                image: url({self._style_manager.get_icon_path('arrow-left')});
-                width: 16px;
-                height: 16px;
+            QPushButton#_mindspace_button:hover {{
+                background-color: {header_hover};
             }}
 
-            QLineEdit[is_valid="true"] {{
-                background-color: {self._style_manager.get_color_str(ColorRole.EDIT_BOX_BACKGROUND)};
-                color: {self._style_manager.get_color_str(ColorRole.TEXT_PRIMARY)};
-                border: 1px solid {self._style_manager.get_color_str(ColorRole.EDIT_BOX_BORDER)};
-                padding: 2px;
-                selection-background-color: {self._style_manager.get_color_str(ColorRole.TEXT_SELECTED)};
-                selection-color: {self._style_manager.get_color_str(ColorRole.TEXT_PRIMARY)};
+            QPushButton#_mindspace_button:pressed {{
+                background-color: {header_pressed};
             }}
-            QLineEdit[is_valid="false"] {{
-                background-color: {self._style_manager.get_color_str(ColorRole.EDIT_BOX_BACKGROUND)};
-                color: {self._style_manager.get_color_str(ColorRole.TEXT_PRIMARY)};
-                border: 1px solid {self._style_manager.get_color_str(ColorRole.EDIT_BOX_ERROR)};
-                padding: 1px;
-                selection-background-color: {self._style_manager.get_color_str(ColorRole.TEXT_SELECTED)};
-                selection-color: {self._style_manager.get_color_str(ColorRole.TEXT_PRIMARY)};
+
+            QPushButton#_mindspace_button:disabled {{
+                color: {disabled_color};
+            }}
+
+            QToolButton#_sidebar_toggle_button {{
+                color: {subtle_text};
+                background-color: transparent;
+                border: none;
+                padding: {rail_padding}px;
+                margin: 0px;
+            }}
+
+            QToolButton#_sidebar_toggle_button:hover {{
+                background-color: {rail_hover};
+            }}
+
+            QToolButton#_settings_button,
+            QToolButton[view_type] {{
+                color: {text_color};
+                background-color: transparent;
+                border: none;
+                padding: {rail_padding}px;
+                margin: 2px 4px;
+                border-radius: {content_radius}px;
+            }}
+
+            QToolButton[view_type]:hover,
+            QToolButton#_settings_button:hover {{
+                background-color: {rail_hover};
+            }}
+
+            QToolButton[view_type]:checked {{
+                background-color: {selected_background};
+                {indicator_side}: {rail_indicator}px solid {accent_color};
+            }}
+
+            QToolButton[view_type]:disabled,
+            QToolButton#_settings_button:disabled {{
+                color: {disabled_color};
+            }}
+
+            QWidget#_content_widget MindspaceConversationsView,
+            QWidget#_content_widget MindspaceFilesView,
+            QWidget#_content_widget MindspacePreviewView,
+            QWidget#_content_widget MindspaceVCSView {{
+                background-color: {content_surface};
+                border: none;
+                border-radius: {content_radius}px;
+            }}
+
+            QToolTip {{
+                background-color: {rail_hover};
+                color: {text_color};
+                border: 1px solid {border_color};
+                padding: 2px 4px;
             }}
         """)
 
-        # Forward style updates to child views
         self._files_view.apply_style()
         self._conversations_view.apply_style()
         self._vcs_view.apply_style()
         self._preview_view.apply_style()
-
-        # Update splitter sizes after style changes (zoom factor may have changed)
-        self._update_splitter_sizes()
+        self._update_button_styling()

--- a/src/humbug/mindspace/preview/mindspace_preview_view.py
+++ b/src/humbug/mindspace/preview/mindspace_preview_view.py
@@ -11,6 +11,7 @@ from PySide6.QtWidgets import (
 )
 
 from humbug.message_box import MessageBox, MessageBoxButton, MessageBoxType
+from humbug.color_role import ColorRole
 from humbug.mindspace.mindspace_collapsible_header import MindspaceCollapsibleHeader
 from humbug.mindspace.mindspace_log_level import MindspaceLogLevel
 from humbug.mindspace.mindspace_manager import MindspaceManager
@@ -57,10 +58,8 @@ class MindspacePreviewView(QWidget):
             self
         )
         self._header.setProperty("splitter", True)
+        self._header.set_collapsible(False)
         self._header.toggled.connect(self._on_header_toggled)
-
-        # Start collapsed by default
-        self._header.set_expanded(False, emit_signal=False)
         layout.addWidget(self._header)
 
         # Create tree view
@@ -97,9 +96,6 @@ class MindspacePreviewView(QWidget):
 
         # Add to layout
         layout.addWidget(self._tree_view)
-
-        # Hide tree view initially since header starts collapsed
-        self._tree_view.hide()
 
         # Hide horizontal scrollbar
         self._tree_view.setHorizontalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
@@ -1023,6 +1019,15 @@ class MindspacePreviewView(QWidget):
         """Update styling when application style changes."""
         zoom_factor = self._style_manager.zoom_factor()
         base_font_size = self._style_manager.base_font_size()
+        panel_bg = self._style_manager.get_color_str(ColorRole.BACKGROUND_TERTIARY)
+        tree_bg = self._style_manager.get_color_str(ColorRole.MINDSPACE_BACKGROUND)
+        tree_hover = self._style_manager.get_color_str(ColorRole.BACKGROUND_TERTIARY_HOVER)
+        tree_selected = self._style_manager.get_color_str(ColorRole.TEXT_SELECTED)
+        border = self._style_manager.get_color_str(ColorRole.MENU_BORDER)
+        text = self._style_manager.get_color_str(ColorRole.TEXT_PRIMARY)
+        branch_icon_size = round(12 * zoom_factor)
+        collapsed_icon = "arrow-right" if self.layoutDirection() == Qt.LayoutDirection.LeftToRight else "arrow-left"
+        expanded_icon = "arrow-down"
 
         # Apply style to header
         self._header.apply_style()
@@ -1040,3 +1045,42 @@ class MindspacePreviewView(QWidget):
 
         # Adjust tree indentation
         self._tree_view.setIndentation(file_icon_size)
+        self.setStyleSheet(f"""
+            MindspacePreviewView {{
+                background-color: {panel_bg};
+            }}
+            MindspacePreviewTreeView {{
+                background-color: {tree_bg};
+                color: {text};
+                border: 1px solid {border};
+                border-top: none;
+                outline: none;
+            }}
+            MindspacePreviewTreeView::item {{
+                color: {text};
+                padding: 3px 0px;
+                margin: 0px;
+            }}
+            MindspacePreviewTreeView::item:hover {{
+                background-color: {tree_hover};
+            }}
+            MindspacePreviewTreeView::item:selected {{
+                background-color: {tree_selected};
+                color: {text};
+            }}
+            MindspacePreviewTreeView::branch {{
+                background-color: {tree_bg};
+            }}
+            MindspacePreviewTreeView::branch:has-children:!has-siblings:closed,
+            MindspacePreviewTreeView::branch:closed:has-children:has-siblings {{
+                image: url("{self._style_manager.get_icon_path(collapsed_icon)}");
+                width: {branch_icon_size}px;
+                height: {branch_icon_size}px;
+            }}
+            MindspacePreviewTreeView::branch:open:has-children:!has-siblings,
+            MindspacePreviewTreeView::branch:open:has-children:has-siblings {{
+                image: url("{self._style_manager.get_icon_path(expanded_icon)}");
+                width: {branch_icon_size}px;
+                height: {branch_icon_size}px;
+            }}
+        """)

--- a/src/humbug/mindspace/preview/mindspace_preview_view.py
+++ b/src/humbug/mindspace/preview/mindspace_preview_view.py
@@ -11,10 +11,10 @@ from PySide6.QtWidgets import (
 )
 
 from humbug.message_box import MessageBox, MessageBoxButton, MessageBoxType
-from humbug.color_role import ColorRole
 from humbug.mindspace.mindspace_collapsible_header import MindspaceCollapsibleHeader
 from humbug.mindspace.mindspace_log_level import MindspaceLogLevel
 from humbug.mindspace.mindspace_manager import MindspaceManager
+from humbug.mindspace.mindspace_pane_style import build_tree_pane_stylesheet
 from humbug.mindspace.mindspace_tree_delegate import MindspaceTreeDelegate
 from humbug.mindspace.mindspace_tree_icon_provider import MindspaceTreeIconProvider
 from humbug.mindspace.mindspace_tree_style import MindspaceTreeStyle
@@ -1019,15 +1019,6 @@ class MindspacePreviewView(QWidget):
         """Update styling when application style changes."""
         zoom_factor = self._style_manager.zoom_factor()
         base_font_size = self._style_manager.base_font_size()
-        panel_bg = self._style_manager.get_color_str(ColorRole.BACKGROUND_TERTIARY)
-        tree_bg = self._style_manager.get_color_str(ColorRole.MINDSPACE_BACKGROUND)
-        tree_hover = self._style_manager.get_color_str(ColorRole.BACKGROUND_TERTIARY_HOVER)
-        tree_selected = self._style_manager.get_color_str(ColorRole.TEXT_SELECTED)
-        border = self._style_manager.get_color_str(ColorRole.MENU_BORDER)
-        text = self._style_manager.get_color_str(ColorRole.TEXT_PRIMARY)
-        branch_icon_size = round(12 * zoom_factor)
-        collapsed_icon = "arrow-right" if self.layoutDirection() == Qt.LayoutDirection.LeftToRight else "arrow-left"
-        expanded_icon = "arrow-down"
 
         # Apply style to header
         self._header.apply_style()
@@ -1045,42 +1036,10 @@ class MindspacePreviewView(QWidget):
 
         # Adjust tree indentation
         self._tree_view.setIndentation(file_icon_size)
-        self.setStyleSheet(f"""
-            MindspacePreviewView {{
-                background-color: {panel_bg};
-            }}
-            MindspacePreviewTreeView {{
-                background-color: {tree_bg};
-                color: {text};
-                border: 1px solid {border};
-                border-top: none;
-                outline: none;
-            }}
-            MindspacePreviewTreeView::item {{
-                color: {text};
-                padding: 3px 0px;
-                margin: 0px;
-            }}
-            MindspacePreviewTreeView::item:hover {{
-                background-color: {tree_hover};
-            }}
-            MindspacePreviewTreeView::item:selected {{
-                background-color: {tree_selected};
-                color: {text};
-            }}
-            MindspacePreviewTreeView::branch {{
-                background-color: {tree_bg};
-            }}
-            MindspacePreviewTreeView::branch:has-children:!has-siblings:closed,
-            MindspacePreviewTreeView::branch:closed:has-children:has-siblings {{
-                image: url("{self._style_manager.get_icon_path(collapsed_icon)}");
-                width: {branch_icon_size}px;
-                height: {branch_icon_size}px;
-            }}
-            MindspacePreviewTreeView::branch:open:has-children:!has-siblings,
-            MindspacePreviewTreeView::branch:open:has-children:has-siblings {{
-                image: url("{self._style_manager.get_icon_path(expanded_icon)}");
-                width: {branch_icon_size}px;
-                height: {branch_icon_size}px;
-            }}
-        """)
+        self.setStyleSheet(build_tree_pane_stylesheet(
+            self._style_manager,
+            "MindspacePreviewView",
+            "MindspacePreviewTreeView",
+            self.layoutDirection(),
+            zoom_factor,
+        ))

--- a/src/humbug/mindspace/vcs/mindspace_vcs_view.py
+++ b/src/humbug/mindspace/vcs/mindspace_vcs_view.py
@@ -119,6 +119,7 @@ class MindspaceVCSView(QWidget):
             self
         )
         self._header.setProperty("splitter", True)
+        self._header.set_collapsible(False)
         self._header.toggled.connect(self._on_header_toggled)
         layout.addWidget(self._header)
 

--- a/src/humbug/mindspace/vcs/mindspace_vcs_view.py
+++ b/src/humbug/mindspace/vcs/mindspace_vcs_view.py
@@ -17,6 +17,7 @@ from humbug.mindspace.mindspace_collapsible_header import MindspaceCollapsibleHe
 from humbug.message_box import MessageBox, MessageBoxButton, MessageBoxType
 from humbug.mindspace.mindspace_log_level import MindspaceLogLevel
 from humbug.mindspace.mindspace_manager import MindspaceManager
+from humbug.mindspace.mindspace_pane_style import build_list_pane_stylesheet
 from humbug.mindspace.vcs.mindspace_vcs_poller import MindspaceVCSPoller
 from humbug.mindspace.vcs.mindspace_vcs_delegate import MindspaceVCSDelegate
 from humbug.mindspace.mindspace_view_type import MindspaceViewType
@@ -177,33 +178,12 @@ class MindspaceVCSView(QWidget):
 
     def _apply_stylesheet(self) -> None:
         """Build and apply the widget stylesheet."""
-        bg = self._style_manager.get_color_str(ColorRole.MINDSPACE_BACKGROUND)
-        selected = self._style_manager.get_color_str(ColorRole.TEXT_SELECTED)
-        hover = self._style_manager.get_color_str(ColorRole.TAB_BACKGROUND_HOVER)
-
-        if self.layoutDirection() == Qt.LayoutDirection.LeftToRight:
-            list_padding = "2px 0 0 5px"
-        else:
-            list_padding = "2px 5px 0 0"
-
-        self.setStyleSheet(f"""
-            QListWidget#_list_widget {{
-                background-color: {bg};
-                border: none;
-                outline: none;
-                padding: {list_padding};
-            }}
-            QListWidget#_list_widget::item {{
-                padding: 2px 0 2px 0;
-                margin: 0px;
-            }}
-            QListWidget#_list_widget::item:selected {{
-                background-color: {selected};
-            }}
-            QListWidget#_list_widget::item:hover {{
-                background-color: {hover};
-            }}
-        """)
+        self.setStyleSheet(build_list_pane_stylesheet(
+            self._style_manager,
+            "MindspaceVCSView",
+            "QListWidget#_list_widget",
+            self.layoutDirection(),
+        ))
 
     def _on_header_toggled(self, expanded: bool) -> None:
         """Show or hide the list when the header is toggled."""

--- a/src/humbug/style_manager.py
+++ b/src/humbug/style_manager.py
@@ -877,6 +877,16 @@ class StyleManager(QObject):
             </svg>
         ''')
 
+        # Files icon
+        self._write_icon(f'{prefix}files-{suffix}.svg', f'''
+            <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                <path d="M4 7C4 5.89543 4.89543 5 6 5H10L12 7H18C19.1046 7 20 7.89543 20 9V17C20 18.1046 19.1046 19 18 19H6
+                    C4.89543 19 4 18.1046 4 17V7Z"
+                    stroke="{color}" stroke-width="2" stroke-linejoin="round"/>
+                <path d="M4 10H20" stroke="{color}" stroke-width="2" stroke-linecap="round"/>
+            </svg>
+        ''')
+
         # Log tab icon (from https://www.svgrepo.com/collection/scarlab-oval-line-icons/)
         self._write_icon(f'{prefix}log-{suffix}.svg', f'''
             <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">


### PR DESCRIPTION
1. Refactor mindspace sidebar into rail + active pane layout
2. Add collapsible sidebar behavior with top-level toggle control
3. Remove per-section expand/collapse controls from mindspace panes
4. Improve sidebar visual design and icon consistency
5. Add shared pane stylesheet helpers for tree and list mindspace views
6. Fix dark theme rendering for mindspace pane headers and trees
7. Restore visible tree disclosure icons for folder expand/collapse
8. Add proper file icon and localize sidebar expand/collapse tooltips
9. Reduce duplicated styling logic across conversations/files/preview/VCS panes