### PR TITLE
Fix settings dialog z-ordering and accordion animation

### DIFF
--- a/src/humbug/main_window.py
+++ b/src/humbug/main_window.py
@@ -81,6 +81,7 @@ class MainWindow(QMainWindow):
 
         self._use_custom_title_bar = sys.platform != "darwin"
         self._window_controls: WindowControlsWidget | None = None
+        self._settings_dialog: SettingsDialog | None = None
         self._resize_drag_active = False
         self._resize_direction: tuple[int, int] = (0, 0)
         self._resize_start_pos: QPoint | None = None
@@ -1524,6 +1525,11 @@ class MainWindow(QMainWindow):
 
     def _on_show_settings_dialog(self, initial_section: str | None = None) -> None:
         """Show the unified settings dialog."""
+        if self._settings_dialog and self._settings_dialog.isVisible():
+            self._settings_dialog.raise_()
+            self._settings_dialog.activateWindow()
+            return
+
         has_mindspace = self._mindspace_manager.has_mindspace()
         mindspace_settings = (
             cast(MindspaceSettings, self._mindspace_manager.settings())
@@ -1532,6 +1538,7 @@ class MainWindow(QMainWindow):
         )
 
         dialog = SettingsDialog(self)
+        self._settings_dialog = dialog
 
         def _on_user_settings_changed(new_settings: UserSettings) -> None:
             try:
@@ -1572,10 +1579,16 @@ class MainWindow(QMainWindow):
                     strings.error_saving_mindspace_settings.format(str(e))
                 )
 
+        def _on_dialog_finished(_result: int) -> None:
+            self._settings_dialog = None
+
         dialog.user_settings_changed.connect(_on_user_settings_changed)
         dialog.mindspace_settings_changed.connect(_on_mindspace_settings_changed)
+        dialog.finished.connect(_on_dialog_finished)
         dialog.set_settings(self._user_manager.settings(), mindspace_settings, initial_section)
-        dialog.exec()
+        dialog.show()
+        dialog.raise_()
+        dialog.activateWindow()
 
     def _on_show_settings_dialog_ai_backends(self) -> None:
         """Show the unified settings dialog opened to the AI Backends section."""

--- a/src/humbug/settings/settings_accordion.py
+++ b/src/humbug/settings/settings_accordion.py
@@ -109,8 +109,7 @@ class SettingsAccordion(SettingsItem):
             # Measure the natural height before constraining it.
             self._content_widget.setMaximumHeight(QWIDGETSIZE_MAX)
             target_h = self._content_widget.sizeHint().height()
-            start_h = 0
-            self._content_widget.setMaximumHeight(0)   # will be driven by animation
+            self._content_widget.setMaximumHeight(start_h)
 
         else:
             target_h = 0
@@ -120,7 +119,8 @@ class SettingsAccordion(SettingsItem):
         anim.setDuration(ACCORDION_ANIM_DURATION_MS)
         anim.setStartValue(start_h)
         anim.setEndValue(target_h)
-        anim.setEasingCurve(QEasingCurve.Type.OutCubic if self._expanded else QEasingCurve.Type.InCubic)
+        anim.setEasingCurve(QEasingCurve.Type.InOutCubic)
+        anim.finished.connect(lambda: self._on_animation_finished(anim, target_expanded))
         anim.start()
         self._animation = anim
 
@@ -171,14 +171,12 @@ class SettingsAccordion(SettingsItem):
         self._chevron.setFixedSize(chevron_size, chevron_size)
         self._header_btn.setMinimumHeight(header_min_height)
 
-        header_bottom_border = "0px" if self._content_visible else "1px"
         header_bottom_radius = 0 if self._content_visible else radius
 
         self._header_btn.setStyleSheet(f"""
             QPushButton#AccordionHeader {{
                 background-color: {bg};
                 border: 1px solid {border_color};
-                border-bottom-width: {header_bottom_border};
                 border-top-left-radius: {radius}px;
                 border-top-right-radius: {radius}px;
                 border-bottom-left-radius: {header_bottom_radius}px;
@@ -221,7 +219,8 @@ class SettingsAccordion(SettingsItem):
         self._content_widget.setStyleSheet(f"""
             QWidget#AccordionContent {{
                 background-color: {content_bg};
-                border-top: 1px solid {border_color};
+                border: 1px solid {border_color};
+                border-top: 0px;
                 border-top-left-radius: 0px;
                 border-top-right-radius: 0px;
                 border-bottom-left-radius: {radius}px;

--- a/src/humbug/settings/settings_accordion.py
+++ b/src/humbug/settings/settings_accordion.py
@@ -24,6 +24,7 @@ class SettingsAccordion(SettingsItem):
         super().__init__(parent)
 
         self._expanded = expanded
+        self._content_visible = expanded
         self._content_items: List[SettingsItem] = []
         self._animation: QPropertyAnimation | None = None
 
@@ -96,32 +97,45 @@ class SettingsAccordion(SettingsItem):
     # ── Private ────────────────────────────────────────────────────────────
 
     def _on_toggle(self) -> None:
-        self._expanded = not self._expanded
-        self._on_style_changed()   # update header border radius + chevron
+        target_expanded = not self._expanded
 
         # Stop any in-progress animation so direction changes feel responsive.
         if self._animation and self._animation.state() == QPropertyAnimation.State.Running:
-            self._animation.stop()
+            active_animation = self._animation
+            self._animation = None
+            active_animation.stop()
 
-        if self._expanded:
+        start_h = self._content_widget.height()
+        self._expanded = target_expanded
+
+        if target_expanded:
+            self._content_visible = True
+            self._on_style_changed()
             # Measure the natural height before constraining it.
             self._content_widget.setMaximumHeight(QWIDGETSIZE_MAX)
             target_h = self._content_widget.sizeHint().height()
-            start_h = 0
-            self._content_widget.setMaximumHeight(0)   # will be driven by animation
+            self._content_widget.setMaximumHeight(start_h)
         else:
-            start_h = self._content_widget.height()
             target_h = 0
+            self._on_style_changed()
 
         anim = QPropertyAnimation(self._content_widget, b"maximumHeight", self)
         anim.setDuration(ACCORDION_ANIM_DURATION_MS)
         anim.setStartValue(start_h)
         anim.setEndValue(target_h)
-        anim.setEasingCurve(
-            QEasingCurve.Type.OutCubic if self._expanded else QEasingCurve.Type.InCubic
-        )
+        anim.setEasingCurve(QEasingCurve.Type.InOutCubic)
+        anim.finished.connect(lambda: self._on_animation_finished(anim, target_expanded))
         anim.start()
         self._animation = anim
+
+    def _on_animation_finished(self, anim: QPropertyAnimation, expanded: bool) -> None:
+        if anim is not self._animation:
+            return
+
+        self._animation = None
+        self._content_visible = expanded
+        self._content_widget.setMaximumHeight(QWIDGETSIZE_MAX if expanded else 0)
+        self._on_style_changed()
 
     def _update_chevron(self) -> None:
         if self._expanded:
@@ -155,14 +169,13 @@ class SettingsAccordion(SettingsItem):
         bg_hover = self._style_manager.get_color_str(ColorRole.BACKGROUND_TERTIARY_HOVER)
         bg_pressed = self._style_manager.get_color_str(ColorRole.BACKGROUND_TERTIARY_PRESSED)
         border_color = self._style_manager.get_color_str(ColorRole.MENU_BORDER)
-        accent = self._style_manager.get_color_str(ColorRole.BUTTON_BACKGROUND_RECOMMENDED)
         radius = 8
 
         self._chevron.setFixedSize(chevron_size, chevron_size)
         self._header_btn.setMinimumHeight(header_min_height)
 
-        header_bottom_border = "0px" if self._expanded else "1px"
-        header_bottom_radius = 0 if self._expanded else radius
+        header_bottom_border = "0px" if self._content_visible else "1px"
+        header_bottom_radius = 0 if self._content_visible else radius
 
         self._header_btn.setStyleSheet(f"""
             QPushButton#AccordionHeader {{
@@ -212,7 +225,7 @@ class SettingsAccordion(SettingsItem):
             QWidget#AccordionContent {{
                 background-color: {content_bg};
                 border: 1px solid {border_color};
-                border-top: 2px solid {accent};
+                border-top: 1px solid {border_color};
                 border-top-left-radius: 0px;
                 border-top-right-radius: 0px;
                 border-bottom-left-radius: {radius}px;

--- a/src/humbug/settings/settings_combo.py
+++ b/src/humbug/settings/settings_combo.py
@@ -171,6 +171,7 @@ class _SettingsComboPopup(QFrame):
 
         self.move(global_pos)
         self.show()
+        self.raise_()
 
         if self._searchable:
             self._search.setFocus(Qt.FocusReason.PopupFocusReason)

--- a/src/humbug/settings_dialog.py
+++ b/src/humbug/settings_dialog.py
@@ -161,8 +161,6 @@ class SettingsDialog(QDialog):
         self.setWindowTitle(strings.settings)
         self.setMinimumWidth(900)
         self.setMinimumHeight(700)
-        self.setModal(True)
-
         self._build_ui()
 
         self._style_manager.style_changed.connect(self._on_style_changed)

--- a/src/humbug/tabs/conversation/conversation_settings_dialog.py
+++ b/src/humbug/tabs/conversation/conversation_settings_dialog.py
@@ -31,7 +31,6 @@ class ConversationSettingsDialog(QDialog):
         self.setWindowTitle(strings.conversation_settings)
         self.setMinimumWidth(800)
         self.setMinimumHeight(600)
-        self.setModal(True)
 
         self._user_manager = UserManager()
         self._ai_backends = self._user_manager.get_ai_backends()

--- a/src/humbug/tabs/conversation/conversation_tab.py
+++ b/src/humbug/tabs/conversation/conversation_tab.py
@@ -4,7 +4,7 @@ import logging
 from typing import Dict, Any
 
 from PySide6.QtWidgets import (
-    QApplication, QDialog, QVBoxLayout, QWidget
+    QApplication, QVBoxLayout, QWidget
 )
 from PySide6.QtCore import QObject, Signal, QRegularExpression
 
@@ -47,6 +47,7 @@ class ConversationTab(TabBase):
         super().__init__(tab_id, parent)
         self._logger = logging.getLogger("ConversationTab")
         self._path = path
+        self._conversation_settings_dialog: ConversationSettingsDialog | None = None
 
         # Create layout
         layout = QVBoxLayout(self)
@@ -433,11 +434,26 @@ class ConversationTab(TabBase):
 
     def show_conversation_settings_dialog(self) -> None:
         """Show the conversation settings dialog."""
+        if self._conversation_settings_dialog and self._conversation_settings_dialog.isVisible():
+            self._conversation_settings_dialog.raise_()
+            self._conversation_settings_dialog.activateWindow()
+            return
+
         dialog = ConversationSettingsDialog(self)
+        self._conversation_settings_dialog = dialog
         dialog.set_settings(self._conversation_widget.conversation_settings())
 
-        if dialog.exec() == QDialog.DialogCode.Accepted:
+        def _on_accepted() -> None:
             self._conversation_widget.update_conversation_settings(dialog.get_settings())
+
+        def _on_finished(_result: int) -> None:
+            self._conversation_settings_dialog = None
+
+        dialog.accepted.connect(_on_accepted)
+        dialog.finished.connect(_on_finished)
+        dialog.show()
+        dialog.raise_()
+        dialog.activateWindow()
 
     def can_navigate_next_message(self) -> bool:
         """Check if navigation to next message is possible."""

--- a/src/humbug/ui_constants.py
+++ b/src/humbug/ui_constants.py
@@ -4,4 +4,4 @@
 QWIDGETSIZE_MAX = 16777215
 
 # Duration in milliseconds for accordion slide animations.
-ACCORDION_ANIM_DURATION_MS = 260
+ACCORDION_ANIM_DURATION_MS = 320


### PR DESCRIPTION
Replace setModal/exec() with show()/raise_() on the settings and conversation settings dialogs so they run at normal window level, allowing OS screenshot overlays to appear on top. Guard against opening a second instance; re-focus the existing dialog instead.

Also fix accordion animation: track content visibility separately from expanded state so border radius updates correctly mid-animation, handle rapid direction changes without orphaned animations, and smooth the easing curve.