### PR TITLE
Dev tab enhancement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 New features:
 
 - Added a `cat` shell command that emulates the functionality of the filesystem AI tool's file read operation.
+- Right-clicking a tab now shows a context menu with options to open a new tab to the left or right, and to close
+  tabs to the left, tabs to the right, or all other tabs in the column.
 - Made VCS (git) polling an async task so it doesn't block the main thread.  Useful on Windows with anti-malware scanners.
 
 Bug fixes:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ New features:
 - Added a `cat` shell command that emulates the functionality of the filesystem AI tool's file read operation.
 - Right-clicking a tab now shows a context menu with options to open a new tab to the left or right, and to close
   tabs to the left, tabs to the right, or all other tabs in the column.
+- Added a tab overview (View -> Show Open Tabs, Ctrl+Shift+E) that shows all open tabs as thumbnail cards, like a
+  mobile recents screen.  Click a card to switch to that tab, swipe/drag it upwards or use its close button to close
+  the tab.  Pressing the shortcut again cycles the selection through the cards; Enter activates the selected tab.
+- Added a tab carousel (View -> Show Tab Carousel, Ctrl+Shift+T) that shows open tabs as a horizontally scrollable
+  card strip with the current tab nearly filling the view.  Scroll, drag the strip sideways, use the arrow keys, or
+  press the shortcut again to flip through tabs; click the centred card (or press Enter) to switch to it, and close
+  a tab with its close button or by swiping its card upwards.
 - Made VCS (git) polling an async task so it doesn't block the main thread.  Useful on Windows with anti-malware scanners.
 
 Bug fixes:

--- a/src/desktop/language/ar/ar_strings.py
+++ b/src/desktop/language/ar/ar_strings.py
@@ -47,6 +47,13 @@ def get_arabic_strings() -> LanguageStrings:
         close_tab="إغلاق التبويب",
         settings="الإعدادات",
 
+        # Tab bar context menu items
+        new_tab_to_left="تبويب جديد إلى اليسار",
+        new_tab_to_right="تبويب جديد إلى اليمين",
+        close_tabs_to_left="إغلاق التبويبات إلى اليسار",
+        close_tabs_to_right="إغلاق التبويبات إلى اليمين",
+        close_other_tabs="إغلاق التبويبات الأخرى",
+
         # Edit menu items
         submit_message="إرسال الرسالة",
         undo="تراجع",
@@ -69,6 +76,8 @@ def get_arabic_strings() -> LanguageStrings:
         reset_zoom="إعادة تعيين التكبير",
         show_system_log="عرض سجل المساحة الذهنية",
         show_system_shell="عرض صدفة هامبغ",
+        show_tab_overview="عرض التبويبات المفتوحة",
+        show_tab_carousel="عرض دوّار التبويبات",
         show_all_columns="عرض كل الأعمدة",
         split_column_left="تقسيم العمود لليسار",
         split_column_right="تقسيم العمود لليمين",

--- a/src/desktop/language/en/en_strings.py
+++ b/src/desktop/language/en/en_strings.py
@@ -46,6 +46,13 @@ def get_english_strings() -> LanguageStrings:
         close_tab="Close Tab",
         settings="Settings",
 
+        # Tab bar context menu items
+        new_tab_to_left="New Tab to the Left",
+        new_tab_to_right="New Tab to the Right",
+        close_tabs_to_left="Close Tabs to the Left",
+        close_tabs_to_right="Close Tabs to the Right",
+        close_other_tabs="Close Other Tabs",
+
         # Edit menu items
         submit_message="Submit Message",
         undo="Undo",
@@ -68,6 +75,8 @@ def get_english_strings() -> LanguageStrings:
         reset_zoom="Reset Zoom",
         show_system_log="Show Mindspace Log",
         show_system_shell="Show Humbug Shell",
+        show_tab_overview="Show Open Tabs",
+        show_tab_carousel="Show Tab Carousel",
         show_all_columns="Show All Columns",
         split_column_left="Split Column Left",
         split_column_right="Split Column Right",

--- a/src/desktop/language/fr/fr_strings.py
+++ b/src/desktop/language/fr/fr_strings.py
@@ -46,6 +46,13 @@ def get_french_strings() -> LanguageStrings:
         close_tab="Fermer l'onglet",
         settings="Paramètres",
 
+        # Tab bar context menu items
+        new_tab_to_left="Nouvel onglet à gauche",
+        new_tab_to_right="Nouvel onglet à droite",
+        close_tabs_to_left="Fermer les onglets à gauche",
+        close_tabs_to_right="Fermer les onglets à droite",
+        close_other_tabs="Fermer les autres onglets",
+
         # Edit menu items
         submit_message="Envoyer le message",
         undo="Annuler",
@@ -68,6 +75,8 @@ def get_french_strings() -> LanguageStrings:
         reset_zoom="Réinitialiser le zoom",
         show_system_log="Afficher le journal de l'espace mental",
         show_system_shell="Afficher le shell Humbug",
+        show_tab_overview="Afficher les onglets ouverts",
+        show_tab_carousel="Afficher le carrousel d'onglets",
         show_all_columns="Afficher toutes les colonnes",
         split_column_left="Diviser la colonne à gauche",
         split_column_right="Diviser la colonne à droite",

--- a/src/desktop/language/language_strings.py
+++ b/src/desktop/language/language_strings.py
@@ -37,6 +37,13 @@ class LanguageStrings:
     close_tab: str
     settings: str
 
+    # Tab bar context menu items
+    new_tab_to_left: str
+    new_tab_to_right: str
+    close_tabs_to_left: str
+    close_tabs_to_right: str
+    close_other_tabs: str
+
     # Edit menu items
     submit_message: str
     undo: str
@@ -59,6 +66,8 @@ class LanguageStrings:
     reset_zoom: str
     show_system_log: str
     show_system_shell: str
+    show_tab_overview: str
+    show_tab_carousel: str
     show_all_columns: str
     split_column_left: str
     split_column_right: str

--- a/src/desktop/main_window.py
+++ b/src/desktop/main_window.py
@@ -70,7 +70,7 @@ from desktop.sidebar_manager import SidebarManager
 from desktop.style_manager import StyleManager, ColorMode
 from desktop.status_message import StatusMessage
 from desktop.system_ai_tool import SystemAITool
-from desktop.tab_manager import TabManager
+from desktop.tab_manager import TabManager, TabManagerError
 from desktop.terminal_tab.terminal_tab import TerminalTab
 from desktop.title_bar import MenuBarDragFilter, WindowControlsWidget
 from desktop.update_checker import UpdateChecker
@@ -387,6 +387,14 @@ class MainWindow(QMainWindow):
         self._show_system_shell_action.setShortcut(QKeySequence("Ctrl+Shift+Y"))
         self._show_system_shell_action.triggered.connect(self._on_show_system_shell)
 
+        self._show_tab_overview_action = QAction(strings.show_tab_overview, self)
+        self._show_tab_overview_action.setShortcut(QKeySequence("Ctrl+Shift+E"))
+        self._show_tab_overview_action.triggered.connect(self._on_show_tab_overview)
+
+        self._show_tab_carousel_action = QAction(strings.show_tab_carousel, self)
+        self._show_tab_carousel_action.setShortcut(QKeySequence("Ctrl+Shift+T"))
+        self._show_tab_carousel_action.triggered.connect(self._on_show_tab_carousel)
+
         self._show_all_columns_action = QAction(strings.show_all_columns, self)
         self._show_all_columns_action.setShortcut(QKeySequence("Ctrl+\\"))
         self._show_all_columns_action.triggered.connect(self._on_show_all_columns)
@@ -478,6 +486,9 @@ class MainWindow(QMainWindow):
         self._view_menu.addAction(self._show_system_log_action)
         self._view_menu.addAction(self._show_system_shell_action)
         self._view_menu.addSeparator()
+        self._view_menu.addAction(self._show_tab_overview_action)
+        self._view_menu.addAction(self._show_tab_carousel_action)
+        self._view_menu.addSeparator()
         self._view_menu.addAction(self._show_all_columns_action)
         self._view_menu.addAction(self._split_column_left_action)
         self._view_menu.addAction(self._split_column_right_action)
@@ -536,6 +547,7 @@ class MainWindow(QMainWindow):
         self._tab_manager.tab_changed.connect(self._on_tab_manager_tab_changed)
         self._tab_manager.user_settings_requested.connect(self._on_show_settings_dialog_ai_backends)
         self._tab_manager.tab_closed.connect(self._on_tab_manager_tab_closed)
+        self._tab_manager.new_tab_requested.connect(self._on_tab_bar_new_tab_requested)
         self._splitter.addWidget(self._tab_manager)
 
         # Register tab factories for session restore and context-open events.
@@ -736,6 +748,8 @@ class MainWindow(QMainWindow):
         self._show_system_log_action.setEnabled(has_mindspace)
         self._show_system_shell_action.setEnabled(has_mindspace)
         self._show_all_columns_action.setEnabled(tab_manager.can_show_all_columns())
+        self._show_tab_overview_action.setEnabled(tab is not None)
+        self._show_tab_carousel_action.setEnabled(tab is not None)
         self._split_column_left_action.setEnabled(tab_manager.can_split_column())
         self._split_column_right_action.setEnabled(tab_manager.can_split_column())
         self._merge_column_left_action.setEnabled(tab_manager.can_merge_column(left_to_right))
@@ -807,6 +821,8 @@ class MainWindow(QMainWindow):
         self._zoom_out_action.setText(strings.zoom_out)
         self._reset_zoom_action.setText(strings.reset_zoom)
         self._show_system_shell_action.setText(strings.show_system_shell)
+        self._show_tab_overview_action.setText(strings.show_tab_overview)
+        self._show_tab_carousel_action.setText(strings.show_tab_carousel)
         self._show_all_columns_action.setText(strings.show_all_columns)
         self._split_column_left_action.setText(strings.split_column_left)
         self._split_column_right_action.setText(strings.split_column_right)
@@ -1563,6 +1579,14 @@ class MainWindow(QMainWindow):
 
         contexts.open(context_type="shell", title="Humbug Shell")
 
+    def _on_show_tab_overview(self) -> None:
+        """Toggle the open-tabs overview overlay."""
+        self._tab_manager.toggle_tab_overview()
+
+    def _on_show_tab_carousel(self) -> None:
+        """Toggle the open-tabs carousel overlay."""
+        self._tab_manager.toggle_tab_carousel()
+
     def _on_show_all_columns(self) -> None:
         """Show all columns equally."""
         self._tab_manager.show_all_columns()
@@ -1674,8 +1698,32 @@ class MainWindow(QMainWindow):
 
     def _on_new_conversation(self) -> None:
         """Create new conversation tab."""
-        if not self._mindspace_manager.has_mindspace():
+        self._create_new_conversation()
+
+    def _on_tab_bar_new_tab_requested(self, column_index: int, insert_index: int) -> None:
+        """
+        Create a new conversation tab at a specific position in a column.
+
+        Args:
+            column_index: Index of the column that should receive the new tab
+            insert_index: Position within the column's tab bar
+        """
+        context_id = self._create_new_conversation()
+        if context_id is None:
             return
+
+        try:
+            self._tab_manager.move_tab_to_column(context_id, column_index)
+
+        except TabManagerError:
+            return
+
+        self._tab_manager.reposition_tab(context_id, column_index, insert_index)
+
+    def _create_new_conversation(self) -> str | None:
+        """Create a new conversation tab and return its context ID, or None on failure."""
+        if not self._mindspace_manager.has_mindspace():
+            return None
 
         try:
             self._mindspace_manager.ensure_mindspace_dir("conversations")
@@ -1692,7 +1740,7 @@ class MainWindow(QMainWindow):
                 MindspaceLogLevel.ERROR,
                 f"User failed to create new conversation: {str(e)}"
             )
-            return
+            return None
 
         try:
             title, full_path = self._generate_conversation_path()
@@ -1713,12 +1761,13 @@ class MainWindow(QMainWindow):
                 MindspaceLogLevel.ERROR,
                 f"User failed to create new conversation: {str(e)}"
             )
-            return
+            return None
 
         self._mindspace_manager.add_interaction(
             MindspaceLogLevel.INFO,
             f"User created new conversation\ntab ID: {context_id}"
         )
+        return context_id
 
     def _on_sidebar_new_conversation_in_folder(self, folder_path: str) -> None:
         """Create a new conversation in a specific folder."""

--- a/src/desktop/tab_manager/tab_bar.py
+++ b/src/desktop/tab_manager/tab_bar.py
@@ -4,7 +4,7 @@ from typing import Dict
 
 from PySide6.QtCore import QEvent, QMimeData, QObject, QPoint, QRect, QSize, Qt, Signal
 from PySide6.QtGui import (
-    QDrag, QFont, QFontMetricsF, QPainter, QPaintEvent, QMouseEvent, QPixmap, QWheelEvent
+    QContextMenuEvent, QDrag, QFont, QFontMetricsF, QPainter, QPaintEvent, QMouseEvent, QPixmap, QWheelEvent
 )
 from PySide6.QtWidgets import QApplication, QTabBar, QToolButton, QWidget
 
@@ -63,6 +63,7 @@ class TabBar(QTabBar):
 
     close_clicked = Signal(str)
     double_clicked = Signal(str)
+    context_menu_requested = Signal(str, QPoint)
 
     def __init__(self, parent: QWidget | None = None) -> None:
         self._style_manager = StyleManager()
@@ -347,6 +348,17 @@ class TabBar(QTabBar):
                     self.double_clicked.emit(data.tab_id)
 
         super().mouseDoubleClickEvent(event)
+
+    def contextMenuEvent(self, event: QContextMenuEvent) -> None:
+        index = self.tabAt(event.pos())
+        if index != -1:
+            data = self._data_for_index(index)
+            if data:
+                self.context_menu_requested.emit(data.tab_id, event.globalPos())
+                event.accept()
+                return
+
+        super().contextMenuEvent(event)
 
     def wheelEvent(self, event: QWheelEvent) -> None:
         """Use wheel or trackpad gestures to scroll the tab strip."""

--- a/src/desktop/tab_manager/tab_carousel.py
+++ b/src/desktop/tab_manager/tab_carousel.py
@@ -1,0 +1,485 @@
+"""Carousel overlay showing open tabs as a horizontally scrollable card strip.
+
+Like tab_overview, this module is purely presentational: it consumes
+TabOverviewEntry display records and emits signals when the user activates,
+closes or dismisses.  The TabManager supplies the data and acts on the signals.
+"""
+
+from typing import List
+
+from PySide6.QtCore import QEasingCurve, QPoint, QRect, QRectF, Qt, QVariantAnimation, Signal
+from PySide6.QtGui import (
+    QColor, QFont, QFontMetricsF, QKeyEvent, QMouseEvent, QPainter, QPainterPath, QPaintEvent,
+    QPen, QWheelEvent
+)
+from PySide6.QtWidgets import QApplication, QWidget
+
+from desktop.color_role import ColorRole
+from desktop.style_manager import StyleManager
+from desktop.tab_manager.tab_overview import TabOverviewEntry, aspect_fill_source_rect
+
+
+class TabCarouselWidget(QWidget):
+    """Full-area overlay presenting open tabs as a centred, scrollable carousel."""
+
+    tab_activated = Signal(str)
+    tab_close_requested = Signal(str)
+    dismissed = Signal()
+
+    def __init__(self, parent: QWidget) -> None:
+        super().__init__(parent)
+        self._style_manager = StyleManager()
+        self._entries: List[TabOverviewEntry] = []
+
+        self._scroll_pos = 0.0
+        self._target_index = 0
+        self._animation: QVariantAnimation | None = None
+        self._wheel_accumulator = 0
+
+        self._press_pos: QPoint | None = None
+        self._press_scroll_pos = 0.0
+        self._press_card_index: int | None = None
+        self._is_dragging = False
+
+        self._swipe_index: int | None = None
+        self._swipe_offset_y = 0.0
+        self._swipe_animation: QVariantAnimation | None = None
+
+        self.setFocusPolicy(Qt.FocusPolicy.StrongFocus)
+        self.setMouseTracking(True)
+
+    def set_entries(self, entries: List[TabOverviewEntry]) -> None:
+        """Replace the displayed entries, centring on the current tab."""
+        self._entries = list(entries)
+        current = next((i for i, e in enumerate(entries) if e.is_current), 0)
+        self._target_index = current
+        self._scroll_pos = float(current)
+        self._stop_animation()
+        self.update()
+
+    def remove_entry(self, tab_id: str) -> None:
+        """Remove the card for a tab that has been closed."""
+        index = next((i for i, e in enumerate(self._entries) if e.tab_id == tab_id), -1)
+        if index == -1:
+            return
+
+        del self._entries[index]
+        if not self._entries:
+            self.update()
+            return
+
+        if self._target_index >= index:
+            self._target_index = max(0, self._target_index - 1)
+
+        self._target_index = min(self._target_index, len(self._entries) - 1)
+        self._scroll_pos = min(self._scroll_pos, float(len(self._entries) - 1))
+        self._go_to(self._target_index)
+
+    def entry_count(self) -> int:
+        """Return the number of entries currently displayed."""
+        return len(self._entries)
+
+    def current_tab_id(self) -> str | None:
+        """Return the tab ID of the centred card, if any."""
+        if not self._entries:
+            return None
+
+        return self._entries[self._target_index].tab_id
+
+    def select_next(self) -> None:
+        """Advance the carousel to the next card, wrapping at the end."""
+        if not self._entries:
+            return
+
+        self._go_to((self._target_index + 1) % len(self._entries))
+
+    def _go_to(self, index: int) -> None:
+        """Animate the carousel so that the card at index is centred."""
+        index = max(0, min(index, len(self._entries) - 1))
+        self._target_index = index
+        self._stop_animation()
+
+        animation = QVariantAnimation(self)
+        animation.setDuration(280)
+        animation.setEasingCurve(QEasingCurve.Type.OutQuart)
+        animation.setStartValue(self._scroll_pos)
+        animation.setEndValue(float(index))
+        animation.valueChanged.connect(self._on_animation_value)
+        self._animation = animation
+        animation.start()
+
+    def _stop_animation(self) -> None:
+        if self._animation is not None:
+            self._animation.stop()
+            self._animation = None
+
+    def _on_animation_value(self, value: object) -> None:
+        self._scroll_pos = float(value)  # type: ignore[arg-type]
+        self.update()
+
+    def _header_height(self) -> int:
+        return self._style_manager.scale(28)
+
+    def _card_spacing(self) -> int:
+        """Horizontal distance between adjacent card centres."""
+        return int(self.width() * 0.52 * 0.95)
+
+    def _card_rect(self, offset: float, index: int | None = None) -> QRect:
+        """
+        Compute the rect for a card at the given fractional offset from centre.
+
+        When an entry index is given the card adopts the aspect ratio of that
+        tab's thumbnail, so the rendered content and its container line up
+        exactly instead of cropping or letterboxing.
+        """
+        max_width = int(self.width() * 0.52)
+        max_height = int(self.height() * 0.66)
+        header_height = self._header_height()
+
+        width = max_width
+        height = max_height
+
+        if index is not None and 0 <= index < len(self._entries):
+            thumbnail = self._entries[index].thumbnail
+            if not thumbnail.isNull() and thumbnail.height() > 0:
+                aspect = thumbnail.width() / thumbnail.height()
+                body_height = max(1, max_height - header_height)
+                body_width = min(max_width, int(body_height * aspect))
+                body_height = max(1, int(body_width / aspect))
+                width = body_width
+                height = body_height + header_height
+
+        scale = max(0.75, 1.0 - 0.12 * abs(offset))
+        width = int(width * scale)
+        height = int(height * scale)
+
+        center_x = self.width() // 2 + int(offset * self._card_spacing())
+        center_y = self.height() // 2
+        return QRect(center_x - width // 2, center_y - height // 2, width, height)
+
+    def _close_rect(self, card_rect: QRect) -> QRect:
+        sm = self._style_manager
+        icon_size = sm.tab_icon_size()
+        spacing = sm.tab_spacing()
+        return QRect(
+            card_rect.right() - spacing - icon_size,
+            card_rect.top() + (self._header_height() - icon_size) // 2,
+            icon_size,
+            icon_size,
+        )
+
+    def _visible_indices(self) -> List[int]:
+        """Return entry indices near enough to the centre to be drawn."""
+        return [
+            i for i in range(len(self._entries))
+            if abs(i - self._scroll_pos) <= 1.6
+        ]
+
+    def paintEvent(self, _event: QPaintEvent) -> None:
+        sm = self._style_manager
+        painter = QPainter(self)
+        painter.setRenderHint(QPainter.RenderHint.Antialiasing)
+
+        dim = QColor(sm.get_color(ColorRole.BACKGROUND_PRIMARY))
+        dim.setAlpha(230)
+        painter.fillRect(self.rect(), dim)
+
+        # Draw far cards first so nearer cards overlap them
+        for index in sorted(self._visible_indices(), key=lambda i: -abs(i - self._scroll_pos)):
+            self._paint_card(painter, index)
+
+    def _paint_card(self, painter: QPainter, index: int) -> None:
+        sm = self._style_manager
+        entry = self._entries[index]
+        offset = index - self._scroll_pos
+        card_rect = self._card_rect(offset, index)
+        is_focused = abs(offset) < 0.5
+        radius = sm.radius("panel")
+
+        is_swiping = index == self._swipe_index and self._swipe_offset_y < 0
+        if is_swiping:
+            card_rect = card_rect.translated(0, int(self._swipe_offset_y))
+            progress = min(1.0, -self._swipe_offset_y / max(1, card_rect.height()))
+            painter.setOpacity(max(0.15, 1.0 - progress))
+
+        painter.save()
+        path = QPainterPath()
+        path.addRoundedRect(card_rect, radius, radius)
+        painter.setClipPath(path)
+
+        painter.fillRect(card_rect, sm.get_color(ColorRole.BACKGROUND_SECONDARY))
+
+        header_height = self._header_height()
+        header_rect = QRect(card_rect.left(), card_rect.top(), card_rect.width(), header_height)
+        painter.fillRect(header_rect, sm.get_color(ColorRole.BACKGROUND_TERTIARY))
+
+        icon_size = sm.tab_icon_size()
+        spacing = sm.tab_spacing()
+        icon_y = card_rect.top() + (header_height - icon_size) // 2
+        painter.drawPixmap(QPoint(card_rect.left() + spacing, icon_y), sm.scale_icon(entry.icon_name, 16))
+
+        font = QFont()
+        font.setFamilies(sm.proportional_font_families())
+        font.setPointSizeF(sm.base_font_size() * sm.zoom_factor())
+        painter.setFont(font)
+        painter.setPen(sm.get_color(ColorRole.TEXT_PRIMARY))
+
+        text_x = card_rect.left() + spacing + icon_size + spacing
+        text_right = self._close_rect(card_rect).left() - spacing if is_focused else card_rect.right() - spacing
+        text_rect = QRect(text_x, card_rect.top(), max(0, text_right - text_x), header_height)
+        fm = QFontMetricsF(font)
+        elided = fm.elidedText(entry.title, Qt.TextElideMode.ElideMiddle, text_rect.width())
+        painter.drawText(text_rect, Qt.AlignmentFlag.AlignVCenter | Qt.AlignmentFlag.AlignLeft, elided)
+
+        if is_focused:
+            close_rect = self._close_rect(card_rect)
+            painter.drawPixmap(close_rect.topLeft(), sm.scale_icon("close", 16))
+
+        body_rect = QRect(
+            card_rect.left(),
+            card_rect.top() + header_height,
+            card_rect.width(),
+            card_rect.height() - header_height,
+        )
+        thumbnail = entry.thumbnail
+        if not thumbnail.isNull() and body_rect.height() > 0:
+            # Rect-to-rect drawing fills the body exactly regardless of the
+            # thumbnail's device pixel ratio
+            painter.setRenderHint(QPainter.RenderHint.SmoothPixmapTransform)
+            source = aspect_fill_source_rect(thumbnail, body_rect)
+            if not source.isEmpty():
+                painter.drawPixmap(body_rect, thumbnail, source)
+
+        # Dim non-focused cards so the centred one stands out
+        if not is_focused:
+            shade = QColor(0, 0, 0)
+            shade.setAlpha(min(120, int(90 * abs(offset))))
+            painter.fillRect(card_rect, shade)
+
+        painter.restore()
+
+        painter.setBrush(Qt.BrushStyle.NoBrush)
+        if is_focused:
+            # Soft halo around the focused card instead of a hard border
+            glow_base = sm.get_color(ColorRole.BRAND_PRIMARY)
+            for ring in range(5, 0, -1):
+                glow = QColor(glow_base)
+                glow.setAlpha(int(70 / ring))
+                pen = QPen(glow)
+                pen.setWidthF(2.0)
+                painter.setPen(pen)
+                painter.drawRoundedRect(
+                    QRectF(card_rect).adjusted(0.5 - ring, 0.5 - ring, ring - 0.5, ring - 0.5),
+                    radius + ring,
+                    radius + ring,
+                )
+
+            # Fine edge line, stroked over the clip boundary so no background
+            # seam shows through at the rounded corners
+            edge = QColor(glow_base)
+            edge.setAlpha(190)
+            pen = QPen(edge)
+            pen.setWidthF(1.5)
+            painter.setPen(pen)
+            painter.drawRoundedRect(
+                QRectF(card_rect).adjusted(0.75, 0.75, -0.75, -0.75), radius, radius
+            )
+
+        else:
+            pen = QPen(sm.get_color(ColorRole.SPLITTER))
+            pen.setWidthF(1.0)
+            painter.setPen(pen)
+            painter.drawRoundedRect(
+                QRectF(card_rect).adjusted(0.5, 0.5, -0.5, -0.5), radius, radius
+            )
+
+        if is_swiping:
+            painter.setOpacity(1.0)
+
+    def wheelEvent(self, event: QWheelEvent) -> None:
+        delta = event.angleDelta().x()
+        if delta == 0:
+            delta = event.angleDelta().y()
+
+        self._wheel_accumulator += delta
+        steps = int(self._wheel_accumulator / 120)
+        if steps != 0:
+            self._wheel_accumulator -= steps * 120
+            self._go_to(self._target_index - steps)
+
+        event.accept()
+
+    def keyPressEvent(self, event: QKeyEvent) -> None:
+        if event.key() == Qt.Key.Key_Escape:
+            self.dismissed.emit()
+            return
+
+        if event.key() in (Qt.Key.Key_Return, Qt.Key.Key_Enter):
+            tab_id = self.current_tab_id()
+            if tab_id is not None:
+                self.tab_activated.emit(tab_id)
+
+            return
+
+        if event.key() == Qt.Key.Key_Right:
+            self._go_to(self._target_index + 1)
+            return
+
+        if event.key() == Qt.Key.Key_Left:
+            self._go_to(self._target_index - 1)
+            return
+
+        super().keyPressEvent(event)
+
+    def mousePressEvent(self, event: QMouseEvent) -> None:
+        if event.button() != Qt.MouseButton.LeftButton:
+            super().mousePressEvent(event)
+            return
+
+        # Defer all click handling to release so a drag can scroll the strip
+        self._stop_animation()
+        self._stop_swipe_animation()
+        self._press_pos = event.pos()
+        self._press_scroll_pos = self._scroll_pos
+        self._press_card_index = self._card_index_at(event.pos())
+        self._is_dragging = False
+
+    def mouseMoveEvent(self, event: QMouseEvent) -> None:
+        if self._press_pos is None or not self._entries:
+            super().mouseMoveEvent(event)
+            return
+
+        delta = event.pos() - self._press_pos
+
+        if not self._is_dragging and self._swipe_index is None:
+            if delta.manhattanLength() < QApplication.startDragDistance():
+                return
+
+            # Pick a gesture axis once: an upward drag on a card swipes it
+            # closed, anything else scrolls the strip
+            if (
+                self._press_card_index is not None
+                and delta.y() < 0
+                and abs(delta.y()) > abs(delta.x())
+            ):
+                self._swipe_index = self._press_card_index
+
+            else:
+                self._is_dragging = True
+
+        if self._swipe_index is not None:
+            self._swipe_offset_y = min(0.0, float(delta.y()))
+            self.update()
+            return
+
+        position = self._press_scroll_pos - delta.x() / max(1, self._card_spacing())
+        self._scroll_pos = max(0.0, min(position, float(len(self._entries) - 1)))
+        self.update()
+
+    def mouseReleaseEvent(self, event: QMouseEvent) -> None:
+        if event.button() != Qt.MouseButton.LeftButton:
+            super().mouseReleaseEvent(event)
+            return
+
+        press_pos = self._press_pos
+        self._press_pos = None
+
+        if self._swipe_index is not None:
+            self._finish_swipe()
+            return
+
+        if self._is_dragging:
+            # Snap after a drag; never treat it as a click.  A short but deliberate
+            # drag pages one card in its direction rather than springing back.
+            self._is_dragging = False
+            target = round(self._scroll_pos)
+            delta = self._scroll_pos - self._press_scroll_pos
+            if target == round(self._press_scroll_pos) and abs(delta) > 0.08:
+                target += 1 if delta > 0 else -1
+
+            self._go_to(target)
+            return
+
+        if press_pos is not None:
+            self._handle_click(event.pos())
+
+    def _card_index_at(self, pos: QPoint) -> int | None:
+        """Return the index of the card under pos, testing nearest-to-centre first."""
+        for index in sorted(self._visible_indices(), key=lambda i: abs(i - self._scroll_pos)):
+            if self._card_rect(index - self._scroll_pos, index).contains(pos):
+                return index
+
+        return None
+
+    def _finish_swipe(self) -> None:
+        """Complete an upward swipe: close past the threshold, else spring back."""
+        index = self._swipe_index
+        if index is None or index >= len(self._entries):
+            self._reset_swipe()
+            return
+
+        card_rect = self._card_rect(index - self._scroll_pos, index)
+        if -self._swipe_offset_y > card_rect.height() * 0.35:
+            tab_id = self._entries[index].tab_id
+            target = -float(card_rect.bottom() + 20)
+            self._animate_swipe(target, on_done=lambda: self._complete_swipe_close(tab_id))
+
+        else:
+            self._animate_swipe(0.0, on_done=self._reset_swipe)
+
+    def _complete_swipe_close(self, tab_id: str) -> None:
+        # Reset before emitting: the close may remove the entry (re-indexing the
+        # list), or be vetoed, in which case the card simply springs back
+        self._reset_swipe()
+        self.tab_close_requested.emit(tab_id)
+
+    def _reset_swipe(self) -> None:
+        self._swipe_index = None
+        self._swipe_offset_y = 0.0
+        self.update()
+
+    def _animate_swipe(self, target: float, on_done: object = None) -> None:
+        self._stop_swipe_animation()
+        animation = QVariantAnimation(self)
+        animation.setDuration(160)
+        animation.setEasingCurve(QEasingCurve.Type.OutCubic)
+        animation.setStartValue(self._swipe_offset_y)
+        animation.setEndValue(target)
+        animation.valueChanged.connect(self._on_swipe_animation_value)
+        if callable(on_done):
+            animation.finished.connect(on_done)
+
+        self._swipe_animation = animation
+        animation.start()
+
+    def _stop_swipe_animation(self) -> None:
+        if self._swipe_animation is not None:
+            self._swipe_animation.stop()
+            self._swipe_animation = None
+
+    def _on_swipe_animation_value(self, value: object) -> None:
+        self._swipe_offset_y = float(value)  # type: ignore[arg-type]
+        self.update()
+
+    def _handle_click(self, pos: QPoint) -> None:
+        """Activate, close, centre or dismiss based on where a clean click landed."""
+        # Test cards nearest the centre first since they are drawn on top
+        for index in sorted(self._visible_indices(), key=lambda i: abs(i - self._scroll_pos)):
+            offset = index - self._scroll_pos
+            card_rect = self._card_rect(offset, index)
+            if not card_rect.contains(pos):
+                continue
+
+            if abs(offset) < 0.5:
+                if self._close_rect(card_rect).contains(pos):
+                    self.tab_close_requested.emit(self._entries[index].tab_id)
+
+                else:
+                    self.tab_activated.emit(self._entries[index].tab_id)
+
+            else:
+                self._go_to(index)
+
+            return
+
+        self.dismissed.emit()

--- a/src/desktop/tab_manager/tab_manager.py
+++ b/src/desktop/tab_manager/tab_manager.py
@@ -392,15 +392,21 @@ class TabManager(QWidget):
         strings = self._language_manager.strings()
         menu = self._style_manager.create_menu(self)
 
+        # In right-to-left layouts the visual order is mirrored, so "left"
+        # corresponds to higher tab indexes and "right" to lower ones
+        left_to_right = self._language_manager.left_to_right()
+        has_tabs_before = tab_index > 0
+        has_tabs_after = tab_index < tab_count - 1
+
         new_left_action = menu.addAction(strings.new_tab_to_left)
         new_right_action = menu.addAction(strings.new_tab_to_right)
         menu.addSeparator()
 
         close_left_action = menu.addAction(strings.close_tabs_to_left)
-        close_left_action.setEnabled(tab_index > 0)
+        close_left_action.setEnabled(has_tabs_before if left_to_right else has_tabs_after)
 
         close_right_action = menu.addAction(strings.close_tabs_to_right)
-        close_right_action.setEnabled(tab_index < tab_count - 1)
+        close_right_action.setEnabled(has_tabs_after if left_to_right else has_tabs_before)
 
         close_others_action = menu.addAction(strings.close_other_tabs)
         close_others_action.setEnabled(tab_count > 1)
@@ -409,16 +415,21 @@ class TabManager(QWidget):
         if action is None:
             return
 
-        if action == new_left_action:
+        new_before_action = new_left_action if left_to_right else new_right_action
+        new_after_action = new_right_action if left_to_right else new_left_action
+        close_before_action = close_left_action if left_to_right else close_right_action
+        close_after_action = close_right_action if left_to_right else close_left_action
+
+        if action == new_before_action:
             self.new_tab_requested.emit(column_index, tab_index)
 
-        elif action == new_right_action:
+        elif action == new_after_action:
             self.new_tab_requested.emit(column_index, tab_index + 1)
 
-        elif action == close_left_action:
+        elif action == close_before_action:
             self._close_tabs_in_column(column, list(range(0, tab_index)))
 
-        elif action == close_right_action:
+        elif action == close_after_action:
             self._close_tabs_in_column(column, list(range(tab_index + 1, tab_count)))
 
         elif action == close_others_action:

--- a/src/desktop/tab_manager/tab_manager.py
+++ b/src/desktop/tab_manager/tab_manager.py
@@ -3,12 +3,13 @@ import logging
 from typing import Callable, Dict, List, cast
 
 from PySide6.QtWidgets import QWidget, QVBoxLayout, QHBoxLayout, QStackedWidget, QApplication
-from PySide6.QtCore import Signal, QTimer
+from PySide6.QtCore import Signal, QTimer, QPoint
 from PySide6.QtGui import QResizeEvent
 
 from context.context_info import ContextInfo
 from context.context_registry import ContextEvent, ContextRegistry
 
+from desktop.language.language_manager import LanguageManager
 from desktop.mindspace.mindspace_manager import MindspaceManager
 from desktop.status_message import StatusMessage
 from desktop.style_manager import StyleManager
@@ -18,7 +19,9 @@ from desktop.tab_manager.column_splitter import ColumnSplitter
 from desktop.tab_manager.column_widget import ColumnWidget
 from desktop.tab_manager.spacer_drop_widget import SpacerDropWidget
 from desktop.tab_manager.tab_bar import TabBar
+from desktop.tab_manager.tab_carousel import TabCarouselWidget
 from desktop.tab_manager.tab_manager_error import TabManagerError
+from desktop.tab_manager.tab_overview import TabOverviewEntry, TabOverviewWidget
 from desktop.tab_manager.tab_style import build_tab_manager_stylesheet, build_tab_bar_stylesheet
 from desktop.tab_manager.welcome_widget import WelcomeWidget
 from desktop.user.user_settings import UserSettings
@@ -34,6 +37,7 @@ class TabManager(QWidget):
     tab_changed = Signal()
     tab_closed = Signal(str)
     user_settings_requested = Signal()
+    new_tab_requested = Signal(int, int)  # column_index, insert_index
 
     def __init__(
         self,
@@ -44,6 +48,7 @@ class TabManager(QWidget):
         super().__init__(parent)
 
         self._mindspace_manager = MindspaceManager()
+        self._language_manager = LanguageManager()
         self._logger = logging.getLogger("TabManager")
 
         # Subscribe to mindspace open/close so we can wire registry callbacks
@@ -125,6 +130,10 @@ class TabManager(QWidget):
         self._tab_factories: Dict[str, TabFactory] = {}
         self._context_factories: Dict[str, ContextFactory] = {}
         self._current_status_tab: TabBase | None = None
+
+        # Lazily-created overlays: grid overview and carousel ("recents screens")
+        self._tab_overview: TabOverviewWidget | None = None
+        self._tab_carousel: TabCarouselWidget | None = None
 
     def register_tab_factory(self, tool_name: str, factory: TabFactory) -> None:
         """Register a tab factory for session restore.
@@ -359,6 +368,75 @@ class TabManager(QWidget):
 
         if tab.is_ephemeral():
             self._make_tab_permanent(tab)
+
+    def _on_tab_label_context_menu(self, tab_id: str, global_pos: QPoint) -> None:
+        """
+        Show the context menu for a tab label.
+
+        Args:
+            tab_id: ID of the tab that was right-clicked
+            global_pos: Global position at which to show the menu
+        """
+        tab = self._tabs.get(tab_id)
+        if tab is None:
+            return
+
+        column = self._find_column_for_tab(tab)
+        if column is None:
+            return
+
+        column_index = self._tab_columns.index(column)
+        tab_index = column.indexOf(tab)
+        tab_count = column.count()
+
+        strings = self._language_manager.strings()
+        menu = self._style_manager.create_menu(self)
+
+        new_left_action = menu.addAction(strings.new_tab_to_left)
+        new_right_action = menu.addAction(strings.new_tab_to_right)
+        menu.addSeparator()
+
+        close_left_action = menu.addAction(strings.close_tabs_to_left)
+        close_left_action.setEnabled(tab_index > 0)
+
+        close_right_action = menu.addAction(strings.close_tabs_to_right)
+        close_right_action.setEnabled(tab_index < tab_count - 1)
+
+        close_others_action = menu.addAction(strings.close_other_tabs)
+        close_others_action.setEnabled(tab_count > 1)
+
+        action = menu.exec_(global_pos)
+        if action is None:
+            return
+
+        if action == new_left_action:
+            self.new_tab_requested.emit(column_index, tab_index)
+
+        elif action == new_right_action:
+            self.new_tab_requested.emit(column_index, tab_index + 1)
+
+        elif action == close_left_action:
+            self._close_tabs_in_column(column, list(range(0, tab_index)))
+
+        elif action == close_right_action:
+            self._close_tabs_in_column(column, list(range(tab_index + 1, tab_count)))
+
+        elif action == close_others_action:
+            self._close_tabs_in_column(column, [i for i in range(tab_count) if i != tab_index])
+
+    def _close_tabs_in_column(self, column: ColumnWidget, indexes: List[int]) -> None:
+        """
+        Close the tabs at the given indexes within a column.
+
+        Args:
+            column: Column containing the tabs
+            indexes: Tab indexes to close, relative to the column's current layout
+        """
+        tab_ids = [cast(TabBase, column.widget(i)).tab_id() for i in indexes]
+        for close_id in tab_ids:
+            self.close_tab_by_id(close_id)
+            if close_id not in self._tabs:
+                self.tab_closed.emit(close_id)
 
     def _on_tab_updated_state_changed(self, _tab_id: str, _is_updated: bool) -> None:
         """
@@ -798,6 +876,133 @@ class TabManager(QWidget):
         if current_index not in (-1, target_index):
             column.tabBar().moveTab(current_index, target_index)
 
+    def toggle_tab_overview(self) -> None:
+        """Show the tab overview, or cycle its selection if it is already visible."""
+        if self._tab_overview is not None and self._tab_overview.isVisible():
+            self._tab_overview.cycle_selection()
+            return
+
+        self.show_tab_overview()
+
+    def show_tab_overview(self) -> None:
+        """Show an overview of all open tabs as a grid of thumbnail cards."""
+        entries = self._build_overview_entries()
+        if not entries:
+            return
+
+        self._hide_tab_carousel()
+
+        if self._tab_overview is None:
+            self._tab_overview = TabOverviewWidget(self)
+            self._tab_overview.tab_activated.connect(self._on_overview_tab_activated)
+            self._tab_overview.tab_close_requested.connect(self._on_overview_tab_close_requested)
+            self._tab_overview.dismissed.connect(self._hide_tab_overview)
+
+        self._tab_overview.set_entries(entries)
+        self._tab_overview.setGeometry(self.rect())
+        self._tab_overview.show()
+        self._tab_overview.raise_()
+        self._tab_overview.setFocus()
+
+    def _hide_tab_overview(self) -> None:
+        """Hide the tab overview overlay and return focus to the current tab."""
+        if self._tab_overview is None or not self._tab_overview.isVisible():
+            return
+
+        self._tab_overview.hide()
+        self._activation_timer.start()
+
+    def toggle_tab_carousel(self) -> None:
+        """Show the tab carousel, or advance it if it is already visible."""
+        if self._tab_carousel is not None and self._tab_carousel.isVisible():
+            self._tab_carousel.select_next()
+            return
+
+        self.show_tab_carousel()
+
+    def show_tab_carousel(self) -> None:
+        """Show a carousel of all open tabs, centred on the current tab."""
+        entries = self._build_overview_entries()
+        if not entries:
+            return
+
+        self._hide_tab_overview()
+
+        if self._tab_carousel is None:
+            self._tab_carousel = TabCarouselWidget(self)
+            self._tab_carousel.tab_activated.connect(self._on_carousel_tab_activated)
+            self._tab_carousel.tab_close_requested.connect(self._on_carousel_tab_close_requested)
+            self._tab_carousel.dismissed.connect(self._hide_tab_carousel)
+
+        self._tab_carousel.set_entries(entries)
+        self._tab_carousel.setGeometry(self.rect())
+        self._tab_carousel.show()
+        self._tab_carousel.raise_()
+        self._tab_carousel.setFocus()
+
+    def _hide_tab_carousel(self) -> None:
+        """Hide the tab carousel overlay and return focus to the current tab."""
+        if self._tab_carousel is None or not self._tab_carousel.isVisible():
+            return
+
+        self._tab_carousel.hide()
+        self._activation_timer.start()
+
+    def _hide_tab_overlays(self) -> None:
+        """Hide both the overview and carousel overlays."""
+        self._hide_tab_overview()
+        self._hide_tab_carousel()
+
+    def _on_carousel_tab_activated(self, tab_id: str) -> None:
+        """Switch to the tab whose carousel card was clicked or chosen."""
+        self._hide_tab_carousel()
+        tab = self._tabs.get(tab_id)
+        if tab is not None:
+            self._set_current_tab(tab, False)
+
+    def _on_carousel_tab_close_requested(self, tab_id: str) -> None:
+        """Close the tab whose carousel close button was clicked."""
+        self.close_tab_by_id(tab_id)
+        if tab_id not in self._tabs:
+            self.tab_closed.emit(tab_id)
+
+    def _build_overview_entries(self) -> List[TabOverviewEntry]:
+        """Build display records for every open tab, in column then tab order."""
+        entries: List[TabOverviewEntry] = []
+        for column in self._tab_columns:
+            is_active_column = column == self._active_column
+            tab_bar = column.tabBar()
+            for i in range(column.count()):
+                tab = cast(TabBase, column.widget(i))
+                title = tab_bar.get_tab_text(i) if isinstance(tab_bar, TabBar) else ""
+                entries.append(TabOverviewEntry(
+                    tab_id=tab.tab_id(),
+                    icon_name=tab.tab_icon(),
+                    title=title,
+                    thumbnail=tab.grab(),
+                    is_current=is_active_column and column.currentWidget() is tab,
+                ))
+
+        return entries
+
+    def _on_overview_tab_activated(self, tab_id: str) -> None:
+        """Switch to the tab whose overview card was clicked."""
+        self._hide_tab_overview()
+        tab = self._tabs.get(tab_id)
+        if tab is not None:
+            self._set_current_tab(tab, False)
+
+    def _on_overview_tab_close_requested(self, tab_id: str) -> None:
+        """Close the tab whose overview card was swiped away."""
+        self.close_tab_by_id(tab_id)
+        if tab_id not in self._tabs:
+            self.tab_closed.emit(tab_id)
+            return
+
+        # The close was vetoed (e.g. the user cancelled a save prompt)
+        if self._tab_overview is not None:
+            self._tab_overview.restore_card(tab_id)
+
     def _update_tab_bar_for_label_change(self, tab: TabBase) -> None:
         """
         Efficiently update the tab bar after a label text change.
@@ -852,6 +1057,7 @@ class TabManager(QWidget):
         if isinstance(tab_bar, TabBar):
             tab_bar.close_clicked.connect(self._on_tab_label_close_clicked)
             tab_bar.double_clicked.connect(self._on_tab_label_double_clicked)
+            tab_bar.context_menu_requested.connect(self._on_tab_label_context_menu)
 
         self.show_all_columns()
         return column_widget
@@ -1036,6 +1242,9 @@ class TabManager(QWidget):
             # If no tabs exist, we need to switch to the columns widget
             self._stack.setCurrentWidget(self._columns_widget)
 
+        # A newly opened tab supersedes the overlay views
+        self._hide_tab_overlays()
+
         prior_active_column = self._active_column
         target_column = self._get_target_column_for_new_tab(requester_id)
 
@@ -1081,6 +1290,17 @@ class TabManager(QWidget):
                 column.setCurrentWidget(next_tab)
 
         self._remove_tab_from_column(tab, column)
+
+        # Keep the overlay views in sync if they're showing
+        if self._tab_overview is not None and self._tab_overview.isVisible():
+            self._tab_overview.remove_card(tab_id)
+            if self._tab_overview.card_count() == 0:
+                self._hide_tab_overview()
+
+        if self._tab_carousel is not None and self._tab_carousel.isVisible():
+            self._tab_carousel.remove_entry(tab_id)
+            if self._tab_carousel.entry_count() == 0:
+                self._hide_tab_carousel()
 
         # If we closed the last tab in the column, close the column unless it's the last column
         if column.count() == 0:
@@ -1594,6 +1814,9 @@ class TabManager(QWidget):
         for tab in self._tabs.values():
             tab.apply_style()
 
+        # Thumbnails and metrics are stale after a style change, so close the overlays
+        self._hide_tab_overlays()
+
     def update_welcome_widget(self, user_settings: UserSettings) -> None:
         """
         Update the welcome widget with current user settings.
@@ -1639,6 +1862,12 @@ class TabManager(QWidget):
         super().resizeEvent(event)
         if self._tab_columns:
             self.show_all_columns()
+
+        if self._tab_overview is not None and self._tab_overview.isVisible():
+            self._tab_overview.setGeometry(self.rect())
+
+        if self._tab_carousel is not None and self._tab_carousel.isVisible():
+            self._tab_carousel.setGeometry(self.rect())
 
     def show_all_columns(self) -> None:
         """Show all columns, sizing each to its preferred width where possible.

--- a/src/desktop/tab_manager/tab_overview.py
+++ b/src/desktop/tab_manager/tab_overview.py
@@ -1,0 +1,459 @@
+"""Overview ("recents screen") overlay showing all open tabs as swipeable cards.
+
+This module is purely presentational.  It knows nothing about tabs, contexts
+or the mindspace: it consumes a list of TabOverviewEntry display records and
+emits signals when the user activates or dismisses a card.  The TabManager is
+responsible for supplying the data and acting on the signals.
+"""
+
+from dataclasses import dataclass
+import math
+from typing import Dict, List
+
+from PySide6.QtCore import (
+    QEasingCurve, QEvent, QPoint, QPropertyAnimation, QRect, QRectF, QSize, Qt, Signal
+)
+from PySide6.QtGui import (
+    QColor, QEnterEvent, QFont, QFontMetricsF, QKeyEvent, QMouseEvent, QPainter, QPainterPath,
+    QPaintEvent, QPen, QPixmap, QResizeEvent
+)
+from PySide6.QtWidgets import QApplication, QGraphicsOpacityEffect, QScrollArea, QWidget
+
+from desktop.color_role import ColorRole
+from desktop.style_manager import StyleManager
+
+
+def aspect_fill_source_rect(thumbnail: QPixmap, target: QRect) -> QRect:
+    """
+    Compute the source crop (in pixmap device pixels) that fills target's aspect ratio.
+
+    Working in the pixmap's own pixel space and drawing rect-to-rect sidesteps
+    device-pixel-ratio mismatches between grabbed thumbnails and the screen.
+    """
+    pw = thumbnail.width()
+    ph = thumbnail.height()
+    if pw <= 0 or ph <= 0 or target.width() <= 0 or target.height() <= 0:
+        return QRect()
+
+    target_aspect = target.width() / target.height()
+    source_aspect = pw / ph
+
+    if source_aspect > target_aspect:
+        crop_width = max(1, int(ph * target_aspect))
+        return QRect((pw - crop_width) // 2, 0, crop_width, ph)
+
+    crop_height = max(1, int(pw / target_aspect))
+    return QRect(0, 0, pw, crop_height)
+
+
+@dataclass
+class TabOverviewEntry:
+    """Display-only record describing one open tab."""
+
+    tab_id: str
+    icon_name: str
+    title: str
+    thumbnail: QPixmap
+    is_current: bool = False
+
+
+class TabOverviewCard(QWidget):
+    """A single tab card: thumbnail plus title bar, closable with an upward swipe."""
+
+    activated = Signal(str)
+    close_requested = Signal(str)
+
+    def __init__(self, entry: TabOverviewEntry, parent: QWidget) -> None:
+        super().__init__(parent)
+        self._style_manager = StyleManager()
+        self._entry = entry
+        self._is_hovered = False
+        self._is_selected = False
+        self._close_hovered = False
+        self._close_pressed = False
+
+        self._press_pos: QPoint | None = None
+        self._home_pos = QPoint()
+        self._is_swiping = False
+
+        self._opacity_effect = QGraphicsOpacityEffect(self)
+        self._opacity_effect.setOpacity(1.0)
+        self.setGraphicsEffect(self._opacity_effect)
+
+        self._animation: QPropertyAnimation | None = None
+
+        self.setMouseTracking(True)
+        self.setCursor(Qt.CursorShape.PointingHandCursor)
+
+    def tab_id(self) -> str:
+        """Return the ID of the tab this card represents."""
+        return self._entry.tab_id
+
+    def set_selected(self, selected: bool) -> None:
+        """Set whether this card carries the keyboard selection highlight."""
+        if self._is_selected != selected:
+            self._is_selected = selected
+            self.update()
+
+    def _close_rect(self) -> QRect:
+        """Return the hit rect of the close button in the card header."""
+        sm = self._style_manager
+        icon_size = sm.tab_icon_size()
+        spacing = sm.tab_spacing()
+        return QRect(
+            self.width() - spacing - icon_size,
+            (self._header_height() - icon_size) // 2,
+            icon_size,
+            icon_size,
+        )
+
+    def set_home_pos(self, pos: QPoint) -> None:
+        """Record the card's resting position within the grid."""
+        self._home_pos = pos
+
+    def restore(self) -> None:
+        """Animate the card back to its grid position at full opacity."""
+        self._opacity_effect.setOpacity(1.0)
+        self._animate_to(self._home_pos)
+
+    def _header_height(self) -> int:
+        return self._style_manager.scale(28)
+
+    def enterEvent(self, event: QEnterEvent) -> None:
+        self._is_hovered = True
+        self.update()
+        super().enterEvent(event)
+
+    def leaveEvent(self, event: QEvent) -> None:
+        self._is_hovered = False
+        self._close_hovered = False
+        self.update()
+        super().leaveEvent(event)
+
+    def mousePressEvent(self, event: QMouseEvent) -> None:
+        if event.button() == Qt.MouseButton.LeftButton:
+            if self._close_rect().contains(event.pos()):
+                self._close_pressed = True
+                return
+
+            self._press_pos = event.pos()
+            self._is_swiping = False
+
+        super().mousePressEvent(event)
+
+    def mouseMoveEvent(self, event: QMouseEvent) -> None:
+        close_hovered = self._close_rect().contains(event.pos())
+        if close_hovered != self._close_hovered:
+            self._close_hovered = close_hovered
+            self.update()
+
+        if self._press_pos is None:
+            super().mouseMoveEvent(event)
+            return
+
+        delta = event.pos() - self._press_pos
+        if not self._is_swiping:
+            if delta.manhattanLength() < QApplication.startDragDistance():
+                return
+
+            # Only a predominantly upward drag starts a swipe
+            if delta.y() >= 0 or abs(delta.x()) > abs(delta.y()):
+                return
+
+            self._is_swiping = True
+
+        offset_y = min(0, delta.y())
+        self.move(self._home_pos + QPoint(0, offset_y))
+        progress = min(1.0, -offset_y / max(1, self.height()))
+        self._opacity_effect.setOpacity(max(0.15, 1.0 - progress))
+
+    def mouseReleaseEvent(self, event: QMouseEvent) -> None:
+        if event.button() != Qt.MouseButton.LeftButton:
+            super().mouseReleaseEvent(event)
+            return
+
+        if self._close_pressed:
+            self._close_pressed = False
+            if self._close_rect().contains(event.pos()):
+                self._emit_close()
+
+            return
+
+        press_pos = self._press_pos
+        self._press_pos = None
+
+        if not self._is_swiping:
+            if press_pos is not None and self.rect().contains(event.pos()):
+                self.activated.emit(self._entry.tab_id)
+
+            return
+
+        self._is_swiping = False
+        dragged = self._home_pos.y() - self.pos().y()
+        if dragged > self.height() * 0.35:
+            self._animate_to(QPoint(self._home_pos.x(), -self.height()), on_done=self._emit_close)
+
+        else:
+            self._opacity_effect.setOpacity(1.0)
+            self._animate_to(self._home_pos)
+
+    def _emit_close(self) -> None:
+        self.close_requested.emit(self._entry.tab_id)
+
+    def _animate_to(self, target: QPoint, on_done: object = None) -> None:
+        animation = QPropertyAnimation(self, b"pos", self)
+        animation.setDuration(150)
+        animation.setEasingCurve(QEasingCurve.Type.OutCubic)
+        animation.setStartValue(self.pos())
+        animation.setEndValue(target)
+        if callable(on_done):
+            animation.finished.connect(on_done)
+
+        self._animation = animation
+        animation.start()
+
+    def paintEvent(self, _event: QPaintEvent) -> None:
+        sm = self._style_manager
+        painter = QPainter(self)
+        painter.setRenderHint(QPainter.RenderHint.Antialiasing)
+
+        radius = sm.radius("panel")
+        card_rect = self.rect().adjusted(0, 0, -1, -1)
+
+        path = QPainterPath()
+        path.addRoundedRect(card_rect, radius, radius)
+        painter.setClipPath(path)
+
+        painter.fillRect(card_rect, sm.get_color(ColorRole.BACKGROUND_SECONDARY))
+
+        header_height = self._header_height()
+        header_rect = QRect(0, 0, card_rect.width(), header_height)
+        painter.fillRect(header_rect, sm.get_color(ColorRole.BACKGROUND_TERTIARY))
+
+        # Type icon and elided title in the header
+        icon_size = sm.tab_icon_size()
+        spacing = sm.tab_spacing()
+        icon_pixmap = sm.scale_icon(self._entry.icon_name, 16)
+        icon_y = (header_height - icon_size) // 2
+        painter.drawPixmap(QPoint(spacing, icon_y), icon_pixmap)
+
+        font = QFont()
+        font.setFamilies(sm.proportional_font_families())
+        font.setPointSizeF(sm.base_font_size() * sm.zoom_factor())
+        painter.setFont(font)
+        painter.setPen(sm.get_color(ColorRole.TEXT_PRIMARY))
+
+        close_rect = self._close_rect()
+        text_x = spacing + icon_size + spacing
+        text_rect = QRect(text_x, 0, close_rect.left() - spacing - text_x, header_height)
+        fm = QFontMetricsF(font)
+        elided = fm.elidedText(self._entry.title, Qt.TextElideMode.ElideMiddle, text_rect.width())
+        painter.drawText(text_rect, Qt.AlignmentFlag.AlignVCenter | Qt.AlignmentFlag.AlignLeft, elided)
+
+        # Close button
+        if self._close_hovered:
+            hover_color = sm.get_color(ColorRole.CLOSE_BUTTON_BACKGROUND_HOVER)
+            painter.setBrush(hover_color)
+            painter.setPen(Qt.PenStyle.NoPen)
+            painter.drawRoundedRect(close_rect, sm.radius(), sm.radius())
+
+        painter.drawPixmap(close_rect.topLeft(), sm.scale_icon("close", 16))
+
+        # Thumbnail fills the body exactly; rect-to-rect drawing keeps this
+        # correct regardless of the thumbnail's device pixel ratio
+        body_rect = QRect(0, header_height, card_rect.width(), card_rect.height() - header_height)
+        thumbnail = self._entry.thumbnail
+        if not thumbnail.isNull() and body_rect.height() > 0:
+            painter.setRenderHint(QPainter.RenderHint.SmoothPixmapTransform)
+            source = aspect_fill_source_rect(thumbnail, body_rect)
+            if not source.isEmpty():
+                painter.drawPixmap(body_rect, thumbnail, source)
+
+        painter.setClipping(False)
+
+        # Border: highlighted when hovered or selected.  A centred pen stroke
+        # covers the clip boundary so no seam shows at the rounded corners.
+        if self._is_hovered or self._is_selected:
+            border_color = sm.get_color(ColorRole.BRAND_PRIMARY)
+            border_width = 2.0
+
+        else:
+            border_color = sm.get_color(ColorRole.SPLITTER)
+            border_width = 1.0
+
+        pen = QPen(border_color)
+        pen.setWidthF(border_width)
+        painter.setPen(pen)
+        painter.setBrush(Qt.BrushStyle.NoBrush)
+        inset = border_width / 2
+        painter.drawRoundedRect(
+            QRectF(card_rect).adjusted(inset, inset, -inset, -inset), radius, radius
+        )
+
+class TabOverviewWidget(QWidget):
+    """Full-area overlay presenting all open tabs as a scrollable grid of cards."""
+
+    tab_activated = Signal(str)
+    tab_close_requested = Signal(str)
+    dismissed = Signal()
+
+    def __init__(self, parent: QWidget) -> None:
+        super().__init__(parent)
+        self._style_manager = StyleManager()
+        self._cards: Dict[str, TabOverviewCard] = {}
+        self._card_order: List[str] = []
+        self._selected_id: str | None = None
+
+        self._scroll_area = QScrollArea(self)
+        self._scroll_area.setWidgetResizable(False)
+        self._scroll_area.setFrameShape(QScrollArea.Shape.NoFrame)
+        self._scroll_area.setHorizontalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
+        self._scroll_area.viewport().setAutoFillBackground(False)
+        self._scroll_area.setStyleSheet("QScrollArea { background: transparent; }")
+
+        self._content = QWidget()
+        self._content.setAutoFillBackground(False)
+        self._content.setStyleSheet("background: transparent;")
+        self._scroll_area.setWidget(self._content)
+
+        self.setFocusPolicy(Qt.FocusPolicy.StrongFocus)
+
+    def set_entries(self, entries: List[TabOverviewEntry]) -> None:
+        """Replace the displayed cards with one card per entry."""
+        for card in self._cards.values():
+            card.deleteLater()
+
+        self._cards.clear()
+        self._card_order = []
+
+        self._selected_id = None
+        for entry in entries:
+            card = TabOverviewCard(entry, self._content)
+            card.activated.connect(self.tab_activated)
+            card.close_requested.connect(self.tab_close_requested)
+            card.show()
+            self._cards[entry.tab_id] = card
+            self._card_order.append(entry.tab_id)
+            if entry.is_current:
+                self._selected_id = entry.tab_id
+
+        if self._selected_id is None and self._card_order:
+            self._selected_id = self._card_order[0]
+
+        self._apply_selection()
+        self._relayout()
+
+    def remove_card(self, tab_id: str) -> None:
+        """Remove the card for a tab that has been closed."""
+        card = self._cards.pop(tab_id, None)
+        if card is None:
+            return
+
+        if tab_id in self._card_order:
+            self._card_order.remove(tab_id)
+
+        card.deleteLater()
+        if self._selected_id == tab_id:
+            self._selected_id = self._card_order[0] if self._card_order else None
+            self._apply_selection()
+
+        self._relayout()
+
+    def cycle_selection(self) -> None:
+        """Move the selection highlight to the next card, wrapping at the end."""
+        if not self._card_order:
+            return
+
+        if self._selected_id in self._card_order:
+            index = (self._card_order.index(self._selected_id) + 1) % len(self._card_order)
+
+        else:
+            index = 0
+
+        self._selected_id = self._card_order[index]
+        self._apply_selection()
+        self._scroll_area.ensureWidgetVisible(self._cards[self._selected_id])
+
+    def selected_tab_id(self) -> str | None:
+        """Return the tab ID of the currently selected card, if any."""
+        return self._selected_id
+
+    def _apply_selection(self) -> None:
+        for tab_id, card in self._cards.items():
+            card.set_selected(tab_id == self._selected_id)
+
+    def restore_card(self, tab_id: str) -> None:
+        """Return a swiped-away card to its grid position (close was vetoed)."""
+        card = self._cards.get(tab_id)
+        if card is not None:
+            card.restore()
+
+    def card_count(self) -> int:
+        """Return the number of cards currently displayed."""
+        return len(self._cards)
+
+    def _card_size(self) -> QSize:
+        sm = self._style_manager
+        return QSize(sm.scale(340), sm.scale(250))
+
+    def _relayout(self) -> None:
+        """Position all cards in a grid sized to the available width."""
+        margin = self._style_manager.scale(24)
+        spacing = self._style_manager.scale(16)
+        card_size = self._card_size()
+
+        available = max(card_size.width(), self.width() - margin * 2)
+        columns = max(1, (available + spacing) // (card_size.width() + spacing))
+        columns = min(columns, max(1, len(self._card_order)))
+
+        rows = math.ceil(len(self._card_order) / columns) if self._card_order else 0
+        content_width = max(self.width(), card_size.width() + margin * 2)
+        content_height = margin * 2 + rows * card_size.height() + max(0, rows - 1) * spacing
+        self._content.resize(content_width, max(content_height, self.height()))
+
+        grid_width = columns * card_size.width() + (columns - 1) * spacing
+        x0 = max(margin, (content_width - grid_width) // 2)
+
+        for i, tab_id in enumerate(self._card_order):
+            row, col = divmod(i, columns)
+            pos = QPoint(
+                x0 + col * (card_size.width() + spacing),
+                margin + row * (card_size.height() + spacing),
+            )
+            card = self._cards[tab_id]
+            card.resize(card_size)
+            card.set_home_pos(pos)
+            card.move(pos)
+
+    def paintEvent(self, _event: QPaintEvent) -> None:
+        painter = QPainter(self)
+        dim = QColor(self._style_manager.get_color(ColorRole.BACKGROUND_PRIMARY))
+        dim.setAlpha(230)
+        painter.fillRect(self.rect(), dim)
+
+    def resizeEvent(self, event: QResizeEvent) -> None:
+        super().resizeEvent(event)
+        self._scroll_area.setGeometry(self.rect())
+        self._relayout()
+
+    def keyPressEvent(self, event: QKeyEvent) -> None:
+        if event.key() == Qt.Key.Key_Escape:
+            self.dismissed.emit()
+            return
+
+        if event.key() in (Qt.Key.Key_Return, Qt.Key.Key_Enter):
+            if self._selected_id is not None:
+                self.tab_activated.emit(self._selected_id)
+
+            return
+
+        if event.key() in (Qt.Key.Key_Right, Qt.Key.Key_Tab):
+            self.cycle_selection()
+            return
+
+        super().keyPressEvent(event)
+
+    def mousePressEvent(self, event: QMouseEvent) -> None:
+        # A press that reaches the overlay itself (not a card) dismisses it
+        self.dismissed.emit()
+        super().mousePressEvent(event)

--- a/src/desktop/tab_manager/tab_overview.py
+++ b/src/desktop/tab_manager/tab_overview.py
@@ -359,13 +359,13 @@ class TabOverviewWidget(QWidget):
 
         self._relayout()
 
-    def cycle_selection(self) -> None:
-        """Move the selection highlight to the next card, wrapping at the end."""
+    def cycle_selection(self, step: int = 1) -> None:
+        """Move the selection highlight by step cards, wrapping at either end."""
         if not self._card_order:
             return
 
         if self._selected_id in self._card_order:
-            index = (self._card_order.index(self._selected_id) + 1) % len(self._card_order)
+            index = (self._card_order.index(self._selected_id) + step) % len(self._card_order)
 
         else:
             index = 0
@@ -436,6 +436,11 @@ class TabOverviewWidget(QWidget):
         self._scroll_area.setGeometry(self.rect())
         self._relayout()
 
+    def focusNextPrevChild(self, next: bool) -> bool:  # pylint: disable=redefined-builtin
+        """Cycle the card selection on Tab/Shift+Tab instead of moving focus."""
+        self.cycle_selection(1 if next else -1)
+        return True
+
     def keyPressEvent(self, event: QKeyEvent) -> None:
         if event.key() == Qt.Key.Key_Escape:
             self.dismissed.emit()
@@ -449,6 +454,10 @@ class TabOverviewWidget(QWidget):
 
         if event.key() in (Qt.Key.Key_Right, Qt.Key.Key_Tab):
             self.cycle_selection()
+            return
+
+        if event.key() in (Qt.Key.Key_Left, Qt.Key.Key_Backtab):
+            self.cycle_selection(-1)
             return
 
         super().keyPressEvent(event)

--- a/tests/desktop/conftest.py
+++ b/tests/desktop/conftest.py
@@ -1,0 +1,89 @@
+"""Shared fixtures for desktop (Qt) widget tests.
+
+These tests exercise the presentational overlay widgets offscreen.  The
+QT_QPA_PLATFORM variable must be set before the QApplication is created.
+"""
+# pylint: disable=redefined-outer-name
+
+import os
+import time
+
+import pytest
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+# pylint: disable=wrong-import-position
+from PySide6.QtCore import QEvent, QPoint, QPointF, Qt
+from PySide6.QtGui import QColor, QMouseEvent, QPixmap
+from PySide6.QtWidgets import QApplication, QWidget
+
+from desktop.tab_manager.tab_overview import TabOverviewEntry
+
+
+@pytest.fixture(scope="session")
+def qapp():
+    """Session-wide QApplication running on the offscreen platform."""
+    app = QApplication.instance() or QApplication([])
+    yield app
+
+
+@pytest.fixture
+def host(qapp):
+    """A parent widget sized like a tab area."""
+    widget = QWidget()
+    widget.resize(1200, 800)
+    yield widget
+    widget.deleteLater()
+    qapp.processEvents()
+
+
+@pytest.fixture
+def make_entries():
+    """Factory for lists of TabOverviewEntry display records."""
+    def _make(count: int = 6, current: int = 2, width: int = 800, height: int = 600, dpr: float = 1.0):
+        pixmap = QPixmap(width, height)
+        pixmap.setDevicePixelRatio(dpr)
+        pixmap.fill(QColor("red"))
+        return [
+            TabOverviewEntry(
+                tab_id=f"t{i}",
+                icon_name="editor",
+                title=f"Tab {i}",
+                thumbnail=pixmap,
+                is_current=(i == current),
+            )
+            for i in range(count)
+        ]
+
+    return _make
+
+
+@pytest.fixture
+def mouse(qapp):
+    """Send a synthetic mouse event to a widget."""
+    def _send(widget, event_type: QEvent.Type, pos: QPoint, button=Qt.MouseButton.LeftButton):
+        buttons = button if event_type != QEvent.Type.MouseButtonRelease else Qt.MouseButton.NoButton
+        event = QMouseEvent(
+            event_type,
+            QPointF(pos),
+            QPointF(pos),
+            QPointF(pos),
+            button,
+            buttons,
+            Qt.KeyboardModifier.NoModifier,
+        )
+        qapp.sendEvent(widget, event)
+
+    return _send
+
+
+@pytest.fixture
+def settle(qapp):
+    """Process events for long enough that in-flight animations finish."""
+    def _settle(ms: int = 450):
+        deadline = time.time() + ms / 1000
+        while time.time() < deadline:
+            qapp.processEvents()
+            time.sleep(0.01)
+
+    return _settle

--- a/tests/desktop/test_tab_carousel.py
+++ b/tests/desktop/test_tab_carousel.py
@@ -1,0 +1,161 @@
+"""Tests for the tab carousel overlay (scrollable centred card strip)."""
+# pylint: disable=protected-access, missing-class-docstring, missing-function-docstring
+
+from PySide6.QtCore import QEvent, QPoint, Qt
+from PySide6.QtGui import QKeyEvent
+
+from desktop.tab_manager.tab_carousel import TabCarouselWidget
+
+
+def make_carousel(host, entries):
+    carousel = TabCarouselWidget(host)
+    carousel.setGeometry(host.rect())
+    carousel.set_entries(entries)
+    carousel.show()
+    return carousel
+
+
+def press_key(qapp, widget, key):
+    qapp.sendEvent(widget, QKeyEvent(QEvent.Type.KeyPress, key, Qt.KeyboardModifier.NoModifier))
+
+
+def centre_of(carousel) -> QPoint:
+    return QPoint(carousel.width() // 2, carousel.height() // 2)
+
+
+class TestNavigation:
+    def test_opens_centred_on_current(self, host, make_entries):
+        carousel = make_carousel(host, make_entries(current=2))
+        assert carousel.current_tab_id() == "t2"
+
+    def test_select_next_wraps(self, host, make_entries):
+        carousel = make_carousel(host, make_entries(count=3, current=2))
+        carousel.select_next()
+        assert carousel.current_tab_id() == "t0"
+
+    def test_arrow_keys_navigate(self, qapp, host, make_entries, settle):
+        carousel = make_carousel(host, make_entries(current=2))
+        press_key(qapp, carousel, Qt.Key.Key_Right)
+        settle()
+        assert carousel.current_tab_id() == "t3"
+
+        press_key(qapp, carousel, Qt.Key.Key_Left)
+        settle()
+        assert carousel.current_tab_id() == "t2"
+
+    def test_enter_activates_centred_card(self, qapp, host, make_entries):
+        carousel = make_carousel(host, make_entries(current=1))
+        activated = []
+        carousel.tab_activated.connect(activated.append)
+        press_key(qapp, carousel, Qt.Key.Key_Return)
+        assert activated == ["t1"]
+
+    def test_escape_dismisses(self, qapp, host, make_entries):
+        carousel = make_carousel(host, make_entries())
+        dismissed = []
+        carousel.dismissed.connect(lambda: dismissed.append(True))
+        press_key(qapp, carousel, Qt.Key.Key_Escape)
+        assert dismissed
+
+    def test_remove_entry_adjusts_position(self, host, make_entries, settle):
+        carousel = make_carousel(host, make_entries(count=3, current=2))
+        carousel.remove_entry("t2")
+        settle()
+        assert carousel.entry_count() == 2
+        assert carousel.current_tab_id() == "t1"
+
+
+class TestGestures:
+    def test_drag_pages_without_activating(self, host, make_entries, mouse, settle):
+        carousel = make_carousel(host, make_entries(current=2))
+        activated = []
+        carousel.tab_activated.connect(activated.append)
+
+        start = centre_of(carousel)
+        mouse(carousel, QEvent.Type.MouseButtonPress, start)
+        mouse(carousel, QEvent.Type.MouseMove, start + QPoint(-150, 0))
+        mouse(carousel, QEvent.Type.MouseButtonRelease, start + QPoint(-150, 0))
+        settle()
+        assert not activated
+        assert carousel.current_tab_id() == "t3"
+
+    def test_clean_click_activates(self, host, make_entries, mouse):
+        carousel = make_carousel(host, make_entries(current=2))
+        activated = []
+        carousel.tab_activated.connect(activated.append)
+
+        centre = centre_of(carousel)
+        mouse(carousel, QEvent.Type.MouseButtonPress, centre)
+        mouse(carousel, QEvent.Type.MouseButtonRelease, centre)
+        assert activated == ["t2"]
+
+    def test_click_outside_cards_dismisses(self, host, make_entries, mouse):
+        carousel = make_carousel(host, make_entries(count=1, current=0))
+        dismissed = []
+        carousel.dismissed.connect(lambda: dismissed.append(True))
+
+        corner = QPoint(5, carousel.height() - 5)
+        mouse(carousel, QEvent.Type.MouseButtonPress, corner)
+        mouse(carousel, QEvent.Type.MouseButtonRelease, corner)
+        assert dismissed
+
+    def test_swipe_up_closes_centred_card(self, host, make_entries, mouse, settle):
+        carousel = make_carousel(host, make_entries(current=2))
+        closed = []
+        carousel.tab_close_requested.connect(closed.append)
+
+        start = centre_of(carousel)
+        mouse(carousel, QEvent.Type.MouseButtonPress, start)
+        mouse(carousel, QEvent.Type.MouseMove, start + QPoint(0, -300))
+        mouse(carousel, QEvent.Type.MouseButtonRelease, start + QPoint(0, -300))
+        settle()
+        assert closed == ["t2"]
+
+    def test_small_swipe_springs_back(self, host, make_entries, mouse, settle):
+        carousel = make_carousel(host, make_entries(current=2))
+        closed = []
+        carousel.tab_close_requested.connect(closed.append)
+
+        start = centre_of(carousel)
+        mouse(carousel, QEvent.Type.MouseButtonPress, start)
+        mouse(carousel, QEvent.Type.MouseMove, start + QPoint(0, -40))
+        mouse(carousel, QEvent.Type.MouseButtonRelease, start + QPoint(0, -40))
+        settle()
+        assert not closed
+
+    def test_horizontal_drag_with_vertical_wobble_scrolls(self, host, make_entries, mouse, settle):
+        carousel = make_carousel(host, make_entries(current=2))
+        closed = []
+        carousel.tab_close_requested.connect(closed.append)
+
+        start = centre_of(carousel)
+        mouse(carousel, QEvent.Type.MouseButtonPress, start)
+        mouse(carousel, QEvent.Type.MouseMove, start + QPoint(-150, -30))
+        mouse(carousel, QEvent.Type.MouseButtonRelease, start + QPoint(-150, -30))
+        settle()
+        assert not closed
+        assert carousel.current_tab_id() == "t3"
+
+    def test_close_button_on_centred_card(self, host, make_entries, mouse):
+        carousel = make_carousel(host, make_entries(current=2))
+        closed = []
+        carousel.tab_close_requested.connect(closed.append)
+
+        card_rect = carousel._card_rect(0.0, 2)
+        pos = carousel._close_rect(card_rect).center()
+        mouse(carousel, QEvent.Type.MouseButtonPress, pos)
+        mouse(carousel, QEvent.Type.MouseButtonRelease, pos)
+        assert closed == ["t2"]
+
+
+class TestGeometry:
+    def test_card_adopts_thumbnail_aspect_ratio(self, host, make_entries):
+        carousel = make_carousel(host, make_entries(width=1000, height=1000))
+        rect = carousel._card_rect(0.0, 0)
+        body_height = rect.height() - carousel._header_height()
+        assert abs(rect.width() / body_height - 1.0) < 0.05
+
+    def test_card_respects_maximum_width(self, host, make_entries):
+        carousel = make_carousel(host, make_entries(width=4000, height=400))
+        rect = carousel._card_rect(0.0, 0)
+        assert rect.width() <= int(carousel.width() * 0.52) + 1

--- a/tests/desktop/test_tab_overview.py
+++ b/tests/desktop/test_tab_overview.py
@@ -1,0 +1,161 @@
+"""Tests for the tab overview overlay (grid of swipeable thumbnail cards)."""
+# pylint: disable=protected-access, missing-class-docstring, missing-function-docstring
+
+from PySide6.QtCore import QEvent, QPoint, QRect, Qt
+from PySide6.QtGui import QKeyEvent, QPixmap
+
+from desktop.tab_manager.tab_overview import TabOverviewWidget, aspect_fill_source_rect
+
+
+def make_overview(host, entries):
+    overview = TabOverviewWidget(host)
+    overview.setGeometry(host.rect())
+    overview.set_entries(entries)
+    overview.show()
+    return overview
+
+
+def press_key(qapp, widget, key, modifier=Qt.KeyboardModifier.NoModifier):
+    qapp.sendEvent(widget, QKeyEvent(QEvent.Type.KeyPress, key, modifier))
+
+
+class TestAspectFillSourceRect:
+    def test_full_pixmap_when_aspect_matches(self):
+        pixmap = QPixmap(800, 600)
+        crop = aspect_fill_source_rect(pixmap, QRect(0, 0, 400, 300))
+        assert crop == QRect(0, 0, 800, 600)
+
+    def test_wide_source_cropped_horizontally_centred(self):
+        pixmap = QPixmap(1600, 600)
+        crop = aspect_fill_source_rect(pixmap, QRect(0, 0, 400, 300))
+        assert crop.height() == 600
+        assert crop.width() == 800
+        assert crop.left() == 400
+
+    def test_tall_source_cropped_to_top(self):
+        pixmap = QPixmap(400, 1200)
+        crop = aspect_fill_source_rect(pixmap, QRect(0, 0, 400, 300))
+        assert crop.top() == 0
+        assert crop.width() == 400
+        assert crop.height() == 300
+
+    def test_degenerate_inputs_give_empty_rect(self):
+        assert aspect_fill_source_rect(QPixmap(), QRect(0, 0, 100, 100)).isEmpty()
+        assert aspect_fill_source_rect(QPixmap(10, 10), QRect(0, 0, 0, 0)).isEmpty()
+
+
+class TestSelection:
+    def test_initial_selection_is_current_tab(self, host, make_entries):
+        overview = make_overview(host, make_entries(current=2))
+        assert overview.selected_tab_id() == "t2"
+
+    def test_cycle_forward_wraps(self, host, make_entries):
+        overview = make_overview(host, make_entries(count=3, current=2))
+        overview.cycle_selection()
+        assert overview.selected_tab_id() == "t0"
+
+    def test_cycle_backward_wraps(self, host, make_entries):
+        overview = make_overview(host, make_entries(count=3, current=0))
+        overview.cycle_selection(-1)
+        assert overview.selected_tab_id() == "t2"
+
+    def test_removing_selected_card_repairs_selection(self, host, make_entries):
+        overview = make_overview(host, make_entries(count=3, current=1))
+        overview.remove_card("t1")
+        assert overview.card_count() == 2
+        assert overview.selected_tab_id() == "t0"
+
+    def test_key_navigation_and_activation(self, qapp, host, make_entries):
+        overview = make_overview(host, make_entries(count=4, current=0))
+        activated = []
+        overview.tab_activated.connect(activated.append)
+
+        press_key(qapp, overview, Qt.Key.Key_Right)
+        press_key(qapp, overview, Qt.Key.Key_Tab)
+        assert overview.selected_tab_id() == "t2"
+
+        press_key(qapp, overview, Qt.Key.Key_Left)
+        press_key(qapp, overview, Qt.Key.Key_Backtab)
+        assert overview.selected_tab_id() == "t0"
+
+        press_key(qapp, overview, Qt.Key.Key_Return)
+        assert activated == ["t0"]
+
+    def test_escape_dismisses(self, qapp, host, make_entries):
+        overview = make_overview(host, make_entries())
+        dismissed = []
+        overview.dismissed.connect(lambda: dismissed.append(True))
+        press_key(qapp, overview, Qt.Key.Key_Escape)
+        assert dismissed
+
+
+class TestCardInteraction:
+    def test_click_activates(self, qapp, host, make_entries, mouse):
+        overview = make_overview(host, make_entries())
+        qapp.processEvents()
+        activated = []
+        overview.tab_activated.connect(activated.append)
+
+        card = overview._cards["t0"]
+        centre = card.rect().center()
+        mouse(card, QEvent.Type.MouseButtonPress, centre)
+        mouse(card, QEvent.Type.MouseButtonRelease, centre)
+        assert activated == ["t0"]
+
+    def test_close_button_emits_close(self, qapp, host, make_entries, mouse):
+        overview = make_overview(host, make_entries())
+        qapp.processEvents()
+        closed = []
+        overview.tab_close_requested.connect(closed.append)
+
+        card = overview._cards["t1"]
+        pos = card._close_rect().center()
+        mouse(card, QEvent.Type.MouseButtonPress, pos)
+        mouse(card, QEvent.Type.MouseButtonRelease, pos)
+        assert closed == ["t1"]
+
+    def test_swipe_up_closes(self, qapp, host, make_entries, mouse, settle):
+        overview = make_overview(host, make_entries())
+        qapp.processEvents()
+        closed = []
+        overview.tab_close_requested.connect(closed.append)
+
+        card = overview._cards["t0"]
+        start = card.rect().center()
+        mouse(card, QEvent.Type.MouseButtonPress, start)
+        mouse(card, QEvent.Type.MouseMove, start + QPoint(0, -card.height()))
+        mouse(card, QEvent.Type.MouseButtonRelease, start + QPoint(0, -card.height()))
+        settle()
+        assert closed == ["t0"]
+
+    def test_small_swipe_springs_back(self, qapp, host, make_entries, mouse, settle):
+        overview = make_overview(host, make_entries())
+        qapp.processEvents()
+        closed = []
+        overview.tab_close_requested.connect(closed.append)
+
+        card = overview._cards["t0"]
+        start = card.rect().center()
+        mouse(card, QEvent.Type.MouseButtonPress, start)
+        mouse(card, QEvent.Type.MouseMove, start + QPoint(0, -20))
+        mouse(card, QEvent.Type.MouseButtonRelease, start + QPoint(0, -20))
+        settle()
+        assert not closed
+
+
+class TestRendering:
+    def test_retina_thumbnail_fills_card_body(self, qapp, host, make_entries):
+        overview = make_overview(host, make_entries(width=1600, height=1200, dpr=2.0))
+        qapp.processEvents()
+
+        card = overview._cards["t0"]
+        image = card.grab().toImage()
+        corner = image.pixelColor(image.width() - 6, image.height() - 6)
+        assert corner.red() > 200
+        assert corner.blue() < 80
+
+    def test_set_entries_replaces_cards(self, host, make_entries):
+        overview = make_overview(host, make_entries(count=5))
+        assert overview.card_count() == 5
+        overview.set_entries(make_entries(count=2))
+        assert overview.card_count() == 2


### PR DESCRIPTION
Add tab context menu, tab overview, and tab carousel views
- Right-clicking a tab now offers: new tab to the left/right, close tabs
  to the left/right, and close all other tabs in the column.  The menu
  uses the shared styled-menu factory so it follows light/dark themes.
- New tab overview (View -> Show Open Tabs, Ctrl+Shift+E): all open tabs
  as thumbnail cards.  Click to switch, swipe up or use the close button
  to close; pressing the shortcut again cycles the selection and Enter
  activates it.
- New tab carousel (View -> Show Tab Carousel, Ctrl+Shift+T): a
  horizontally scrollable card strip centred on the current tab, with
  drag/wheel/arrow navigation, swipe-up-to-close, and a brand-coloured
  halo on the focused card.
- Both overlays are purely presentational (TabOverviewEntry + signals);
  TabManager mediates all tab operations.  Thumbnails render correctly
  on high-DPI displays, and cards adopt each tab's aspect ratio.
- Localised new strings in English, French, and Arabic.