### PR TITLE
Refresh VCS panel promptly on edits

### DIFF
--- a/src/desktop/editor_tab/editor_widget.py
+++ b/src/desktop/editor_tab/editor_widget.py
@@ -467,6 +467,11 @@ class EditorWidget(QPlainTextEdit):
             self._logger.warning("Failed to remove backup file %s: %s", backup_file, str(e))
 
         self.file_saved.emit(self._path)
+
+        # Refresh the VCS panel immediately: a working-tree edit changes git
+        # status but touches neither .git/HEAD nor .git/index, so the poller
+        # would otherwise only notice it on its next timed poll.
+        MindspaceVCSPoller().force_refresh()
         return True
 
     def save_file_as(self) -> bool:

--- a/src/desktop/mindspace/mindspace_vcs_poller.py
+++ b/src/desktop/mindspace/mindspace_vcs_poller.py
@@ -15,7 +15,7 @@ from git import (
 from desktop.file_watcher.file_watcher import FileWatcher
 
 
-_POLL_INTERVAL_MS = 10000
+_POLL_INTERVAL_MS = 3000
 
 
 @dataclass


### PR DESCRIPTION
Shorten the status poll interval from 10s to 3s, and trigger an immediate refresh when a file is saved in the editor, since a working-tree edit changes git status without touching .git/HEAD or .git/index (which the watcher keys on).

1	Add git backend (operations, log, repository, status): dev ← pr/git-backend

2	Add VCS source-control sidebar, history tab, and file icons: pr/git-backend ← pr/vcs-ui

3	Restrict git discovery to the mindspace boundary: pr/vcs-ui ← pr/vcs-boundary

4	Refresh VCS panel promptly on edits (polling):  pr/vcs-ui ← pr/vcs-polling