### PR TITLE
Add automated dev environment setup scripts for menai + humbug

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,13 @@ Developer dependencies (installed automatically with `.[dev]`):
 
 2. Install all dependencies (runtime and developer tools):
 
+   **Option A — automated:** run `./setup-dev.sh` (Linux/macOS/Git Bash) or `.\setup-dev.ps1`
+   (Windows PowerShell) from the repo root. Either creates/reuses the virtual environment,
+   clones the Menai language engine as a sibling repository, installs both packages, and
+   fetches the Menai C VM binary (step 4 below) in one go. Safe to re-run.
+
+   **Option B — manual:**
+
    ```bash
    pip install -e ".[dev]"
    ```
@@ -258,6 +265,11 @@ Developer dependencies (installed automatically with `.[dev]`):
    ```
 
    The `../menai` path is expected by `fetch-menai-vm.py` and the build scripts.
+
+   Note: `menai` isn't on PyPI, so if you run these as two separate `pip install` commands,
+   install `../menai` **before** `pip install -e ".[dev]"` (or combine them into one command,
+   `pip install -e ../menai -e ".[dev]"`) — otherwise pip will fail trying to resolve `menai`
+   from PyPI.
 
 3. Launch the application:
 

--- a/setup-dev.ps1
+++ b/setup-dev.ps1
@@ -1,0 +1,83 @@
+# Bootstrap a Humbug developer environment on Windows (PowerShell): creates
+# the venv, installs Humbug + dev dependencies, clones/installs the sibling
+# Menai repo, and fetches the prebuilt Menai C VM binary.
+#
+# Usage: .\setup-dev.ps1
+# Safe to re-run: existing venv/menai checkout are reused, not recreated.
+
+$ErrorActionPreference = "Stop"
+
+# $ErrorActionPreference only catches PowerShell-native errors, not a
+# non-zero exit code from an external command (pip, git, python) - check
+# explicitly after each critical step so failures stop the script here
+# rather than silently cascading, matching bash's `set -e`.
+function Assert-Success {
+    param([string]$Message)
+    if ($LASTEXITCODE -ne 0) {
+        Write-Error $Message
+        exit $LASTEXITCODE
+    }
+}
+
+Set-Location -Path $PSScriptRoot
+
+$VenvDir = "venv"
+$MenaiDir = "..\menai"
+
+$PythonCmd = Get-Command python -ErrorAction SilentlyContinue
+if (-not $PythonCmd) {
+    $PythonCmd = Get-Command py -ErrorAction SilentlyContinue
+}
+if (-not $PythonCmd) {
+    Write-Error "No 'python' or 'py' command found on PATH. Install Python 3.10+ first."
+    exit 1
+}
+$Python = $PythonCmd.Name
+
+Write-Host "==> Python virtual environment"
+if (Test-Path $VenvDir) {
+    Write-Host "    $VenvDir already exists, reusing it"
+} else {
+    & $Python -m venv $VenvDir
+    Assert-Success "Failed to create virtual environment."
+}
+
+$ActivateScript = Join-Path $VenvDir "Scripts\Activate.ps1"
+& $ActivateScript
+
+pip install --upgrade pip
+Assert-Success "Failed to upgrade pip."
+
+Write-Host "==> Menai language engine"
+# Cloned and installed in the same pip invocation as Humbug below: humbug's
+# pyproject.toml requires "menai", which isn't on PyPI, so both editable
+# installs must be resolved together in one command.
+if (Test-Path $MenaiDir) {
+    Write-Host "    $MenaiDir already exists, reusing it"
+} else {
+    git clone https://github.com/m6r-ai/menai.git $MenaiDir
+    Assert-Success "Failed to clone the Menai repository."
+}
+
+Write-Host "==> Installing Menai + Humbug (runtime + dev dependencies)"
+pip install -e $MenaiDir -e ".[dev]"
+Assert-Success "Failed to install Menai/Humbug dependencies."
+
+Write-Host "==> Fetching prebuilt Menai C VM binary"
+python fetch-menai-vm.py
+if ($LASTEXITCODE -ne 0) {
+    Write-Host "    No prebuilt binary available for this platform."
+    Write-Host "    Falling back to building from source (requires a C compiler):"
+    Push-Location $MenaiDir
+    try {
+        python setup.py build_ext --inplace
+    } finally {
+        Pop-Location
+    }
+}
+
+Write-Host ""
+Write-Host "Setup complete. Activate the environment with:"
+Write-Host "    $ActivateScript"
+Write-Host "Then launch Humbug with:"
+Write-Host "    python -m desktop"

--- a/setup-dev.sh
+++ b/setup-dev.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+#
+# Bootstrap a Humbug developer environment: creates the venv, installs
+# Humbug + dev dependencies, clones/installs the sibling Menai repo, and
+# fetches the prebuilt Menai C VM binary.
+#
+# Usage: ./setup-dev.sh
+# Safe to re-run: existing venv/menai checkout are reused, not recreated.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
+VENV_DIR="venv"
+MENAI_DIR="../menai"
+
+if command -v python3 >/dev/null 2>&1; then
+    PYTHON="python3"
+else
+    PYTHON="python"
+fi
+
+echo "==> Python virtual environment"
+if [ -d "$VENV_DIR" ]; then
+    echo "    $VENV_DIR already exists, reusing it"
+else
+    "$PYTHON" -m venv "$VENV_DIR"
+fi
+
+# Windows venvs (including under Git Bash) use Scripts/ instead of bin/.
+if [ -d "$VENV_DIR/Scripts" ]; then
+    VENV_BIN="$VENV_DIR/Scripts"
+else
+    VENV_BIN="$VENV_DIR/bin"
+fi
+
+# shellcheck disable=SC1091
+source "$VENV_BIN/activate"
+
+pip install --upgrade pip
+
+echo "==> Menai language engine"
+# Cloned and installed in the same pip invocation as Humbug below: humbug's
+# pyproject.toml requires "menai", which isn't on PyPI, so both editable
+# installs must be resolved together in one command.
+if [ -d "$MENAI_DIR" ]; then
+    echo "    $MENAI_DIR already exists, reusing it"
+else
+    git clone https://github.com/m6r-ai/menai.git "$MENAI_DIR"
+fi
+echo "==> Installing Menai + Humbug (runtime + dev dependencies)"
+pip install -e "$MENAI_DIR" -e ".[dev]"
+
+echo "==> Fetching prebuilt Menai C VM binary"
+if ! python fetch-menai-vm.py; then
+    echo "    No prebuilt binary available for this platform."
+    echo "    Falling back to building from source (requires a C compiler):"
+    (cd "$MENAI_DIR" && python setup.py build_ext --inplace)
+fi
+
+echo
+echo "Setup complete. Activate the environment with:"
+echo "    source $VENV_BIN/activate"
+echo "Then launch Humbug with:"
+echo "    python -m desktop"


### PR DESCRIPTION
menai isn't published on PyPI, so `pip install -e ".[dev]"` fails unless the sibling repo is cloned and installed first in the same resolution pass. Add setup-dev.sh (Linux/macOS/Git Bash) and setup-dev.ps1 (Windows PowerShell) to automate venv creation, the Menai clone/install, and the C VM binary fetch with a source-build fallback. Document both as an option in the README's developer installation steps.