### PR TITLE
Dev user onboarding tour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ New features:
   ensures the correct message boxes are highlighted after scrolling and deferred content is revealed.
 - Added pinning of conversations within the mindspace sidebar.
 - Added undo/redo for deletions of conversations from the sidebar.
+- Added an interactive onboarding product tour that spotlights the key parts of Humbug for first-time users.  It can
+  be replayed at any time from Humbug → Take a Tour.
 
 Bug fixes:
 

--- a/src/desktop/conversation_tab/conversation_input.py
+++ b/src/desktop/conversation_tab/conversation_input.py
@@ -107,6 +107,10 @@ class ConversationInput(ConversationMessage):
         self._current_model = model
         self._update_banner_text()
 
+    def submit_button(self) -> QToolButton | None:
+        """Return the submit button, used as an onboarding tour target."""
+        return self._submit_button
+
     def _on_language_changed(self) -> None:
         """Handle language change event."""
         self._update_banner_text()

--- a/src/desktop/conversation_tab/conversation_tab.py
+++ b/src/desktop/conversation_tab/conversation_tab.py
@@ -106,6 +106,10 @@ class ConversationTab(TabBase):
         """Return the tool name for this tab type."""
         return "conversation"
 
+    def conversation_widget(self) -> ConversationWidget:
+        """Return the conversation widget, used as an onboarding tour target."""
+        return self._conversation_widget
+
     def tab_title_from_path(self) -> str:
         """Return the conversation title derived from the filename (without extension)."""
         return os.path.splitext(os.path.basename(self._path))[0] if self._path else ""

--- a/src/desktop/conversation_tab/conversation_widget.py
+++ b/src/desktop/conversation_tab/conversation_widget.py
@@ -8,7 +8,7 @@ import re
 from typing import Any, cast
 
 from PySide6.QtWidgets import (
-    QWidget, QApplication, QVBoxLayout, QScrollArea, QSizePolicy, QFileDialog
+    QWidget, QApplication, QVBoxLayout, QScrollArea, QSizePolicy, QFileDialog, QToolButton
 )
 from PySide6.QtCore import QTimer, QPoint, Qt, Signal, QObject, QEvent, QSize, QUrl, QVariantAnimation
 from PySide6.QtGui import QCursor, QDesktopServices, QFont, QGuiApplication, QIcon, QResizeEvent
@@ -343,6 +343,14 @@ class ConversationWidget(QWidget):
 
         # The last SYSTEM error message widget that has a retry button showing
         self._last_error_message_widget: ConversationMessage | None = None
+
+    def scroll_area(self) -> QScrollArea:
+        """Return the message history scroll area, used as an onboarding tour target."""
+        return self._scroll_area
+
+    def submit_button(self) -> QToolButton | None:
+        """Return the message submit button, used as an onboarding tour target."""
+        return self._input.submit_button()
 
     def _activate_widget(self, widget: QWidget) -> None:
         """

--- a/src/desktop/language/ar/ar_strings.py
+++ b/src/desktop/language/ar/ar_strings.py
@@ -48,6 +48,7 @@ def get_arabic_strings() -> LanguageStrings:
         close_tab="إغلاق التبويب",
         settings="الإعدادات",
         recent_mindspaces="فتح مساحة ذهنية حديثة",
+        take_tour="أخذ جولة",
 
         # Tab bar context menu items
         close_tabs_to_left="إغلاق التبويبات إلى اليسار",
@@ -508,6 +509,36 @@ def get_arabic_strings() -> LanguageStrings:
         fetched_models_title="النماذج المسترجعة — {0}",
         no_fetched_models="لا توجد نماذج مسترجعة لهذا المزود.",
         fetched_models_close="إغلاق",
+
+        # Onboarding product tour
+        tour_step_of="الخطوة {0} من {1}",
+        tour_back_button="رجوع",
+        tour_skip_button="تخطي الجولة",
+        tour_next_button="التالي",
+        tour_finish_button="ابدأ استخدام Humbug",
+        tour_welcome_title="مرحباً بك في Humbug",
+        tour_welcome_description=(
+            "يساعدك Humbug على التعاون مع الذكاء الاصطناعي في مشاريعك — الدردشة، وتعديل الملفات، "
+            "وتشغيل الطرفيات، ومراجعة التغييرات، كل ذلك في مساحة عمل واحدة. لنأخذ جولة سريعة."
+        ),
+        tour_start_here_title="ابدأ من هنا",
+        tour_start_here_description="انقر هنا لإنشاء أو فتح مساحة ذهنية — مساحة عمل مشروعك في Humbug.",
+        tour_open_conversation_title="فتح محادثة",
+        tour_open_conversation_description=(
+            "انقر هنا لفتح لوحة المحادثات — انقر بزر الماوس الأيمن هناك (أو استخدم ملف ← محادثة جديدة) "
+            "لبدء الدردشة مع الذكاء الاصطناعي."
+        ),
+        tour_workspace_title="مساحة عملك",
+        tour_workspace_description="تُفتح المحادثات وعلامات التبويب الأخرى هنا. هذا هو المكان الذي ستقوم فيه بمعظم عملك.",
+        tour_key_action_title="إرسال رسالة",
+        tour_key_action_description="اكتب رسالة واضغط على إرسال (أو Ctrl+Enter) للتحدث مع الذكاء الاصطناعي.",
+        tour_output_title="سجل المحادثة",
+        tour_output_description="تظهر ردود الذكاء الاصطناعي وسجل محادثتك هنا أثناء الدردشة.",
+        tour_navigation_title="التنقل",
+        tour_navigation_description="بدّل بين المحادثات والملفات والبحث والمعاينة والمزيد باستخدام هذا الشريط الجانبي.",
+        tour_help_title="الإعدادات والمساعدة",
+        tour_help_description="افتح الإعدادات هنا في أي وقت. يمكنك إعادة تشغيل هذه الجولة من Humbug ← أخذ جولة.",
+
         fetched_models_remove="إزالة",
 
         fetch_error_invalid_key="مفتاح API غير صالح — يرجى التحقق من مفتاحك والمحاولة مجدداً.",

--- a/src/desktop/language/ar/ar_strings.py
+++ b/src/desktop/language/ar/ar_strings.py
@@ -531,7 +531,7 @@ def get_arabic_strings() -> LanguageStrings:
         tour_workspace_title="مساحة عملك",
         tour_workspace_description="تُفتح المحادثات وعلامات التبويب الأخرى هنا. هذا هو المكان الذي ستقوم فيه بمعظم عملك.",
         tour_key_action_title="إرسال رسالة",
-        tour_key_action_description="اكتب رسالة واضغط على إرسال (أو Ctrl+Enter) للتحدث مع الذكاء الاصطناعي.",
+        tour_key_action_description="اكتب رسالة واضغط على إرسال (أو {0}) للتحدث مع الذكاء الاصطناعي.",
         tour_output_title="سجل المحادثة",
         tour_output_description="تظهر ردود الذكاء الاصطناعي وسجل محادثتك هنا أثناء الدردشة.",
         tour_navigation_title="التنقل",

--- a/src/desktop/language/en/en_strings.py
+++ b/src/desktop/language/en/en_strings.py
@@ -47,6 +47,7 @@ def get_english_strings() -> LanguageStrings:
         close_tab="Close Tab",
         settings="Settings",
         recent_mindspaces="Open Recent Mindspace",
+        take_tour="Take a Tour",
 
         # Tab bar context menu items
         close_tabs_to_left="Close Tabs to the Left",
@@ -512,6 +513,36 @@ def get_english_strings() -> LanguageStrings:
         fetched_models_title="Fetched Models — {0}",
         no_fetched_models="No fetched models for this provider.",
         fetched_models_close="Close",
+
+        # Onboarding product tour
+        tour_step_of="Step {0} of {1}",
+        tour_back_button="Back",
+        tour_skip_button="Skip Tour",
+        tour_next_button="Next",
+        tour_finish_button="Start Using Humbug",
+        tour_welcome_title="Welcome to Humbug",
+        tour_welcome_description=(
+            "Humbug helps you collaborate with AI on your projects — chat, edit files, run terminals, "
+            "and review changes, all in one workspace. Let's take a quick tour."
+        ),
+        tour_start_here_title="Start Here",
+        tour_start_here_description="Click here to create or open a mindspace — your project workspace in Humbug.",
+        tour_open_conversation_title="Open a Conversation",
+        tour_open_conversation_description=(
+            "Click here to open the Conversations panel — right-click there (or use File → New Conversation) "
+            "to start chatting with the AI."
+        ),
+        tour_workspace_title="Your Workspace",
+        tour_workspace_description="Conversations and other tabs open here. This is where you'll do most of your work.",
+        tour_key_action_title="Send a Message",
+        tour_key_action_description="Type a message and press Send (or Ctrl+Enter) to talk with the AI.",
+        tour_output_title="Conversation History",
+        tour_output_description="AI responses and your conversation history appear here as you chat.",
+        tour_navigation_title="Navigation",
+        tour_navigation_description="Switch between Conversations, Files, Search, Preview, and more using this sidebar.",
+        tour_help_title="Settings & Help",
+        tour_help_description="Open Settings here anytime. You can restart this tour from Humbug → Take a Tour.",
+
         fetched_models_remove="Remove",
 
         fetch_error_invalid_key="Invalid API key — please check your key and try again.",

--- a/src/desktop/language/en/en_strings.py
+++ b/src/desktop/language/en/en_strings.py
@@ -535,7 +535,7 @@ def get_english_strings() -> LanguageStrings:
         tour_workspace_title="Your Workspace",
         tour_workspace_description="Conversations and other tabs open here. This is where you'll do most of your work.",
         tour_key_action_title="Send a Message",
-        tour_key_action_description="Type a message and press Send (or Ctrl+Enter) to talk with the AI.",
+        tour_key_action_description="Type a message and press Send (or {0}) to talk with the AI.",
         tour_output_title="Conversation History",
         tour_output_description="AI responses and your conversation history appear here as you chat.",
         tour_navigation_title="Navigation",

--- a/src/desktop/language/fr/fr_strings.py
+++ b/src/desktop/language/fr/fr_strings.py
@@ -47,6 +47,7 @@ def get_french_strings() -> LanguageStrings:
         close_tab="Fermer l'onglet",
         settings="Paramètres",
         recent_mindspaces="Ouvrir un espace mental récent",
+        take_tour="Faire une visite guidée",
 
         # Tab bar context menu items
         close_tabs_to_left="Fermer les onglets à gauche",
@@ -515,6 +516,49 @@ def get_french_strings() -> LanguageStrings:
         fetched_models_title="Modèles récupérés — {0}",
         no_fetched_models="Aucun modèle récupéré pour ce fournisseur.",
         fetched_models_close="Fermer",
+
+        # Onboarding product tour
+        tour_step_of="Étape {0} sur {1}",
+        tour_back_button="Précédent",
+        tour_skip_button="Ignorer la visite",
+        tour_next_button="Suivant",
+        tour_finish_button="Commencer à utiliser Humbug",
+        tour_welcome_title="Bienvenue dans Humbug",
+        tour_welcome_description=(
+            "Humbug vous aide à collaborer avec l'IA sur vos projets — discutez, modifiez des fichiers, "
+            "exécutez des terminaux et examinez les modifications, le tout dans un seul espace de travail. "
+            "Faisons une visite rapide."
+        ),
+        tour_start_here_title="Commencez ici",
+        tour_start_here_description=(
+            "Cliquez ici pour créer ou ouvrir un espace mental — votre espace de travail de projet dans Humbug."
+        ),
+        tour_open_conversation_title="Ouvrir une conversation",
+        tour_open_conversation_description=(
+            "Cliquez ici pour ouvrir le panneau Conversations — faites un clic droit à cet endroit (ou utilisez "
+            "Fichier → Nouvelle conversation) pour commencer à discuter avec l'IA."
+        ),
+        tour_workspace_title="Votre espace de travail",
+        tour_workspace_description=(
+            "Les conversations et autres onglets s'ouvrent ici. C'est ici que vous ferez l'essentiel de votre travail."
+        ),
+        tour_key_action_title="Envoyer un message",
+        tour_key_action_description="Tapez un message et appuyez sur Envoyer (ou Ctrl+Entrée) pour discuter avec l'IA.",
+        tour_output_title="Historique de la conversation",
+        tour_output_description=(
+            "Les réponses de l'IA et l'historique de votre conversation apparaissent ici au fil de la discussion."
+        ),
+        tour_navigation_title="Navigation",
+        tour_navigation_description=(
+            "Passez d'un panneau à l'autre (Conversations, Fichiers, Recherche, Aperçu, etc.) "
+            "grâce à cette barre latérale."
+        ),
+        tour_help_title="Paramètres et aide",
+        tour_help_description=(
+            "Ouvrez les Paramètres ici à tout moment. Vous pouvez relancer cette visite depuis "
+            "Humbug → Faire une visite guidée."
+        ),
+
         fetched_models_remove="Supprimer",
 
         fetch_error_invalid_key="Clé API invalide — veuillez vérifier votre clé et réessayer.",

--- a/src/desktop/language/fr/fr_strings.py
+++ b/src/desktop/language/fr/fr_strings.py
@@ -543,7 +543,7 @@ def get_french_strings() -> LanguageStrings:
             "Les conversations et autres onglets s'ouvrent ici. C'est ici que vous ferez l'essentiel de votre travail."
         ),
         tour_key_action_title="Envoyer un message",
-        tour_key_action_description="Tapez un message et appuyez sur Envoyer (ou Ctrl+Entrée) pour discuter avec l'IA.",
+        tour_key_action_description="Tapez un message et appuyez sur Envoyer (ou {0}) pour discuter avec l'IA.",
         tour_output_title="Historique de la conversation",
         tour_output_description=(
             "Les réponses de l'IA et l'historique de votre conversation apparaissent ici au fil de la discussion."

--- a/src/desktop/language/language_strings.py
+++ b/src/desktop/language/language_strings.py
@@ -505,7 +505,7 @@ class LanguageStrings:
     tour_workspace_title: str
     tour_workspace_description: str
     tour_key_action_title: str
-    tour_key_action_description: str
+    tour_key_action_description: str  # Format: "... ({0}) ..." — {0} is the platform submit shortcut
     tour_output_title: str
     tour_output_description: str
     tour_navigation_title: str

--- a/src/desktop/language/language_strings.py
+++ b/src/desktop/language/language_strings.py
@@ -38,6 +38,7 @@ class LanguageStrings:
     close_tab: str
     settings: str
     recent_mindspaces: str
+    take_tour: str
 
     # Tab bar context menu items
     close_tabs_to_left: str
@@ -488,4 +489,27 @@ class LanguageStrings:
     fetched_models_title: str  # Format: "Fetched Models — {0}"
     no_fetched_models: str
     fetched_models_close: str
+
+    # Onboarding product tour
+    tour_step_of: str  # Format: "Step {0} of {1}"
+    tour_back_button: str
+    tour_skip_button: str
+    tour_next_button: str
+    tour_finish_button: str
+    tour_welcome_title: str
+    tour_welcome_description: str
+    tour_start_here_title: str
+    tour_start_here_description: str
+    tour_open_conversation_title: str
+    tour_open_conversation_description: str
+    tour_workspace_title: str
+    tour_workspace_description: str
+    tour_key_action_title: str
+    tour_key_action_description: str
+    tour_output_title: str
+    tour_output_description: str
+    tour_navigation_title: str
+    tour_navigation_description: str
+    tour_help_title: str
+    tour_help_description: str
     fetched_models_remove: str

--- a/src/desktop/main_window.py
+++ b/src/desktop/main_window.py
@@ -77,6 +77,7 @@ from desktop.status_message import StatusMessage
 from desktop.tab_manager import TabManager
 from desktop.terminal_tab.terminal_tab import TerminalTab
 from desktop.title_bar import MenuBarDragFilter, WindowControlsWidget
+from desktop.tour.tour_controller import TourController
 from desktop.trash_sidebar.trash_sidebar import TrashSidebar
 from desktop.update_checker import UpdateChecker
 from desktop.update_dialog import UpdateDialog
@@ -284,6 +285,10 @@ class MainWindow(QMainWindow):
         self._check_for_updates_action.setMenuRole(QAction.MenuRole.ApplicationSpecificRole)
         self._check_for_updates_action.triggered.connect(self._on_check_for_updates)
 
+        self._take_tour_action = QAction(strings.take_tour, self)
+        self._take_tour_action.setMenuRole(QAction.MenuRole.ApplicationSpecificRole)
+        self._take_tour_action.triggered.connect(self._on_take_tour)
+
         self._settings_action = QAction(strings.settings, self)
         self._settings_action.setMenuRole(QAction.MenuRole.PreferencesRole)
         self._settings_action.setShortcut(QKeySequence("Ctrl+,"))
@@ -482,6 +487,7 @@ class MainWindow(QMainWindow):
         self._humbug_menu = self._menu_bar.addMenu(strings.humbug_menu)
         self._humbug_menu.addAction(self._about_action)
         self._humbug_menu.addAction(self._check_for_updates_action)
+        self._humbug_menu.addAction(self._take_tour_action)
         self._humbug_menu.addSeparator()
         self._humbug_menu.addAction(self._settings_action)
         self._humbug_menu.addSeparator()
@@ -770,6 +776,12 @@ class MainWindow(QMainWindow):
         self._update_checker.update_available.connect(self._on_update_available)
         QTimer.singleShot(5000, self._run_startup_update_check)
 
+        self._tour_controller = TourController(self)
+        self._tour_start_timer = QTimer(self)
+        self._tour_start_timer.setSingleShot(True)
+        self._tour_start_timer.timeout.connect(self._tour_controller.maybe_start_on_launch)
+        self._tour_start_timer.start(400)
+
     def changeEvent(self, event: QEvent) -> None:
         """Handle change events."""
         super().changeEvent(event)
@@ -785,6 +797,18 @@ class MainWindow(QMainWindow):
             is_maximised = bool(state & (Qt.WindowState.WindowMaximized | Qt.WindowState.WindowFullScreen))
             self._window_controls.set_maximised(is_maximised)
 
+
+    def sidebar_manager(self) -> SidebarManager:
+        """Return the sidebar manager, used by the onboarding tour to locate spotlight targets."""
+        return self._sidebar_manager
+
+    def tab_manager(self) -> TabManager:
+        """Return the tab manager, used by the onboarding tour to locate spotlight targets."""
+        return self._tab_manager
+
+    def _on_take_tour(self) -> None:
+        """Restart the onboarding product tour from the beginning."""
+        self._tour_controller.start()
 
     def _on_exception_occurred(self) -> None:
         """Handle uncaught exception notification by activating canary."""
@@ -907,6 +931,7 @@ class MainWindow(QMainWindow):
         # Update action texts
         self._about_action.setText(strings.about_humbug)
         self._check_for_updates_action.setText(strings.check_for_updates)
+        self._take_tour_action.setText(strings.take_tour)
         self._settings_action.setText(strings.settings)
         self._quit_action.setText(strings.quit_humbug)
         self._new_mindspace_action.setText(strings.new_mindspace)

--- a/src/desktop/sidebar_manager/sidebar_manager.py
+++ b/src/desktop/sidebar_manager/sidebar_manager.py
@@ -277,6 +277,17 @@ class SidebarManager(QWidget):
         """
         return self._panel_widgets.get(panel_id)
 
+    def panel_button(self, panel_id: str) -> QToolButton | None:
+        """
+        Return the rail button for panel_id, or None if not registered.
+
+        Used by the onboarding tour to spotlight a specific rail button (e.g. "conversations").
+
+        Args:
+            panel_id: The panel to look up.
+        """
+        return self._panel_buttons.get(panel_id)
+
     def _set_active_panel(self, panel_id: str) -> None:
         """
         Make the given panel current in the stacked pane.
@@ -362,6 +373,18 @@ class SidebarManager(QWidget):
     def content_min_width(self) -> int:
         """Return the minimum width of the sidebar content pane."""
         return self._content_min_width
+
+    def header_widget(self) -> QWidget:
+        """Return the mindspace picker header button, used as an onboarding tour target."""
+        return self._header_widget
+
+    def rail_widget(self) -> QWidget:
+        """Return the icon rail widget, used as an onboarding tour target."""
+        return self._rail_widget
+
+    def settings_button(self) -> QWidget:
+        """Return the settings button, used as an onboarding tour target."""
+        return self._settings_button
 
     def reveal_and_select_file(self, panel_id: str, file_path: str) -> None:
         """

--- a/src/desktop/tour/__init__.py
+++ b/src/desktop/tour/__init__.py
@@ -1,0 +1,5 @@
+from desktop.tour.tour_controller import TourController
+
+__all__ = [
+    "TourController",
+]

--- a/src/desktop/tour/tour_controller.py
+++ b/src/desktop/tour/tour_controller.py
@@ -1,0 +1,129 @@
+"""Controller for the Humbug onboarding product tour."""
+
+import logging
+from typing import TYPE_CHECKING
+
+from PySide6.QtCore import QEvent, QObject
+
+from desktop.language.language_manager import LanguageManager
+from desktop.tour.tour_overlay import TourOverlay
+from desktop.tour.tour_step import TourStep
+from desktop.tour.tour_steps import build_tour_steps
+from desktop.user.onboarding_tour_status import OnboardingTourStatus
+from desktop.user.user_manager import UserError, UserManager
+
+if TYPE_CHECKING:
+    from desktop.main_window import MainWindow
+
+CURRENT_TOUR_VERSION = 1
+
+
+class TourController(QObject):
+    """
+    Drives the onboarding product tour.
+
+    Owns the current step index, resolves each step's spotlight target,
+    persists tour completion state via UserManager, and creates or tears
+    down the presentational TourOverlay as the tour starts and finishes.
+    """
+
+    def __init__(self, main_window: "MainWindow", steps: list[TourStep] | None = None) -> None:
+        super().__init__(main_window)
+        self._logger = logging.getLogger("TourController")
+        self._main_window = main_window
+        self._user_manager = UserManager()
+        self._language_manager = LanguageManager()
+        self._steps = steps if steps is not None else build_tour_steps()
+        self._index = 0
+        self._overlay: TourOverlay | None = None
+
+    def maybe_start_on_launch(self) -> None:
+        """Start the tour automatically if this user has not seen the current tour version."""
+        settings = self._user_manager.settings()
+        if settings.onboarding_tour_version >= CURRENT_TOUR_VERSION:
+            return
+
+        self.start()
+
+    def start(self) -> None:
+        """Start (or restart) the tour from the first step."""
+        self._index = 0
+
+        if self._overlay is None:
+            central_widget = self._main_window.centralWidget()
+            self._overlay = TourOverlay(central_widget)
+            self._overlay.setGeometry(central_widget.rect())
+            self._overlay.next_requested.connect(self._on_next)
+            self._overlay.back_requested.connect(self._on_back)
+            self._overlay.skip_requested.connect(self._on_skip)
+            self._main_window.installEventFilter(self)
+
+        self._show_current_step()
+
+    def eventFilter(self, watched: QObject, event: QEvent) -> bool:
+        if self._overlay is not None and watched is self._main_window and event.type() == QEvent.Type.Resize:
+            self._overlay.setGeometry(self._main_window.centralWidget().rect())
+            self._overlay.refresh_layout()
+
+        return super().eventFilter(watched, event)
+
+    def _show_current_step(self) -> None:
+        """Render the overlay for the step at the current index."""
+        assert self._overlay is not None
+        strings = self._language_manager.strings()
+        step = self._steps[self._index]
+        is_last = self._index == len(self._steps) - 1
+
+        self._overlay.show_step(
+            title=step.title(strings),
+            description=step.description(strings),
+            step_label=strings.tour_step_of.format(self._index + 1, len(self._steps)),
+            back_label=strings.tour_back_button,
+            skip_label=strings.tour_skip_button,
+            next_label=strings.tour_finish_button if is_last else strings.tour_next_button,
+            can_go_back=self._index > 0,
+            spotlight_target=step.resolve_target(self._main_window),
+        )
+
+    def _on_next(self) -> None:
+        """Advance to the next step, or complete the tour if this was the last one."""
+        if self._index >= len(self._steps) - 1:
+            self._finish(OnboardingTourStatus.COMPLETED)
+            return
+
+        self._index += 1
+        self._show_current_step()
+
+    def _on_back(self) -> None:
+        """Return to the previous step, if there is one."""
+        if self._index == 0:
+            return
+
+        self._index -= 1
+        self._show_current_step()
+
+    def _on_skip(self) -> None:
+        """End the tour early at the user's request."""
+        self._finish(OnboardingTourStatus.SKIPPED)
+
+    def _finish(self, status: OnboardingTourStatus) -> None:
+        """Fade out and tear down the overlay, and persist the tour's final status."""
+        overlay = self._overlay
+        self._overlay = None
+        if overlay is not None:
+            self._main_window.removeEventFilter(self)
+            overlay.fade_out(lambda: self._cleanup_overlay(overlay))
+
+        settings = self._user_manager.settings()
+        settings.onboarding_tour_status = status
+        settings.onboarding_tour_version = CURRENT_TOUR_VERSION
+        try:
+            self._user_manager.update_settings(settings)
+
+        except UserError as e:
+            self._logger.warning("Failed to persist onboarding tour state: %s", str(e))
+
+    def _cleanup_overlay(self, overlay: TourOverlay) -> None:
+        """Hide and destroy an overlay once its fade-out animation has finished."""
+        overlay.hide()
+        overlay.deleteLater()

--- a/src/desktop/tour/tour_overlay.py
+++ b/src/desktop/tour/tour_overlay.py
@@ -1,0 +1,548 @@
+"""
+Overlay widget for the Humbug onboarding product tour.
+
+This module is purely presentational.  It knows nothing about tour steps,
+persistence or the wider application: it is told what to display and emits
+signals when the user navigates or dismisses the tour.  TourController is
+responsible for supplying the step content and acting on the signals.
+"""
+
+from collections.abc import Callable
+
+from PySide6.QtCore import (
+    QAbstractAnimation, QEasingCurve, QPoint, QPropertyAnimation, QRect, QRectF, QSize, Qt, QVariantAnimation, Signal
+)
+from PySide6.QtGui import QColor, QKeyEvent, QPainter, QPainterPath, QPaintEvent, QPen, QResizeEvent
+from PySide6.QtWidgets import QGraphicsOpacityEffect, QHBoxLayout, QLabel, QPushButton, QScrollArea, QVBoxLayout, QWidget
+
+from desktop.color_role import ColorRole
+from desktop.style_manager import StyleManager
+
+
+def _scroll_target_into_view(target: QWidget) -> None:
+    """Ask the nearest enclosing scroll area (if any) to reveal target."""
+    ancestor = target.parentWidget()
+    while ancestor is not None:
+        if isinstance(ancestor, QScrollArea):
+            ancestor.ensureWidgetVisible(target)
+            return
+
+        ancestor = ancestor.parentWidget()
+
+
+_OVERLAY_FADE_DURATION_MS = 220
+_SPOTLIGHT_GLIDE_DURATION_MS = 450
+_PULSE_DURATION_MS = 1400
+_PULSE_MIN_ALPHA = 0.35
+_PULSE_MAX_ALPHA = 1.0
+_DIM_BASE_ALPHA = 210
+
+
+class TourOverlay(QWidget):
+    """
+    Full-area overlay that dims the application and spotlights one widget at a time.
+
+    Only the card itself carries a QGraphicsOpacityEffect.  Qt's effect
+    compositing breaks (silently, with a painter-reentrancy error) when a
+    widget with an effect has an ancestor that also has one, so the dim
+    background and the pulsing ring are plain manual painting driven by
+    tracked alpha values instead.
+    """
+
+    next_requested = Signal()
+    back_requested = Signal()
+    skip_requested = Signal()
+
+    def __init__(self, parent: QWidget) -> None:
+        super().__init__(parent)
+        self._style_manager = StyleManager()
+        self._spotlight_rect = QRect()
+        self._current_target: QWidget | None = None
+        self._has_shown_step = False
+        self._card_fade_animation: QPropertyAnimation | None = None
+        self._dim_fade_animation: QVariantAnimation | None = None
+        self._spotlight_animation: QVariantAnimation | None = None
+        self._spotlight_alpha_animation: QVariantAnimation | None = None
+        self._card_position_animation: QVariantAnimation | None = None
+        self._dim_alpha = 0.0
+        self._pulse_alpha = _PULSE_MIN_ALPHA
+        self._spotlight_alpha = 0.0
+
+        self.setFocusPolicy(Qt.FocusPolicy.StrongFocus)
+
+        self._pulse_animation = QVariantAnimation(self)
+        self._pulse_animation.setDuration(_PULSE_DURATION_MS)
+        self._pulse_animation.setLoopCount(-1)
+        self._pulse_animation.setEasingCurve(QEasingCurve.Type.InOutSine)
+        self._pulse_animation.setKeyValueAt(0.0, _PULSE_MIN_ALPHA)
+        self._pulse_animation.setKeyValueAt(0.5, _PULSE_MAX_ALPHA)
+        self._pulse_animation.setKeyValueAt(1.0, _PULSE_MIN_ALPHA)
+        self._pulse_animation.valueChanged.connect(self._on_pulse_value_changed)
+
+        self._card = QWidget(self)
+        self._card.setObjectName("_tour_card")
+
+        self._opacity_effect = QGraphicsOpacityEffect(self._card)
+        self._opacity_effect.setOpacity(0.0)
+        self._card.setGraphicsEffect(self._opacity_effect)
+
+        card_layout = QVBoxLayout(self._card)
+        self._card_layout = card_layout
+
+        self._step_label = QLabel(self._card)
+        card_layout.addWidget(self._step_label)
+
+        self._title_label = QLabel(self._card)
+        self._title_label.setWordWrap(True)
+        card_layout.addWidget(self._title_label)
+
+        self._description_label = QLabel(self._card)
+        self._description_label.setWordWrap(True)
+        card_layout.addWidget(self._description_label)
+
+        button_row = QHBoxLayout()
+        self._skip_button = QPushButton(self._card)
+        self._skip_button.clicked.connect(self.skip_requested)
+        button_row.addWidget(self._skip_button)
+        button_row.addStretch()
+
+        self._back_button = QPushButton(self._card)
+        self._back_button.clicked.connect(self.back_requested)
+        button_row.addWidget(self._back_button)
+
+        self._next_button = QPushButton(self._card)
+        self._next_button.clicked.connect(self.next_requested)
+        button_row.addWidget(self._next_button)
+
+        card_layout.addLayout(button_row)
+
+        self.apply_style()
+
+    def apply_style(self) -> None:
+        """Refresh colours, fonts and spacing from the style manager."""
+        sm = self._style_manager
+        base_font_size = sm.base_font_size() * sm.zoom_factor()
+        radius = sm.radius("panel")
+        card_width = sm.scale(320)
+
+        self._card.setFixedWidth(card_width)
+        self._card_layout.setContentsMargins(sm.scale(16), sm.scale(16), sm.scale(16), sm.scale(16))
+        self._card_layout.setSpacing(sm.scale(8))
+
+        self._card.setStyleSheet(f"""
+            QWidget#_tour_card {{
+                background-color: {sm.get_color_str(ColorRole.BACKGROUND_DIALOG)};
+                border: 1px solid {sm.get_color_str(ColorRole.SPLITTER)};
+                border-radius: {radius}px;
+            }}
+        """)
+
+        self._step_label.setStyleSheet(
+            f"color: {sm.get_color_str(ColorRole.TEXT_INACTIVE)}; font-size: {base_font_size * 0.9}pt; border: none;"
+        )
+        self._title_label.setStyleSheet(
+            f"color: {sm.get_color_str(ColorRole.TEXT_HEADING)}; "
+            f"font-size: {base_font_size * 1.1}pt; font-weight: bold; border: none;"
+        )
+        self._description_label.setStyleSheet(
+            f"color: {sm.get_color_str(ColorRole.TEXT_PRIMARY)}; font-size: {base_font_size}pt; border: none;"
+        )
+
+        button_style = f"""
+            QPushButton {{
+                background-color: {sm.get_color_str(ColorRole.BUTTON_SECONDARY_BACKGROUND)};
+                color: {sm.get_color_str(ColorRole.TEXT_PRIMARY)};
+                border: none;
+                border-radius: {sm.radius()}px;
+                padding: {sm.scale(4)}px {sm.scale(10)}px;
+                font-size: {base_font_size}pt;
+            }}
+            QPushButton:hover {{
+                background-color: {sm.get_color_str(ColorRole.BUTTON_SECONDARY_BACKGROUND_HOVER)};
+            }}
+            QPushButton:pressed {{
+                background-color: {sm.get_color_str(ColorRole.BUTTON_SECONDARY_BACKGROUND_PRESSED)};
+            }}
+        """
+        self._skip_button.setStyleSheet(button_style)
+        self._back_button.setStyleSheet(button_style)
+
+        self._next_button.setStyleSheet(f"""
+            QPushButton {{
+                background-color: {sm.get_color_str(ColorRole.BUTTON_BACKGROUND_RECOMMENDED)};
+                color: {sm.get_color_str(ColorRole.TEXT_RECOMMENDED)};
+                border: none;
+                border-radius: {sm.radius()}px;
+                padding: {sm.scale(4)}px {sm.scale(10)}px;
+                font-size: {base_font_size}pt;
+            }}
+            QPushButton:hover {{
+                background-color: {sm.get_color_str(ColorRole.BUTTON_BACKGROUND_RECOMMENDED_HOVER)};
+            }}
+            QPushButton:pressed {{
+                background-color: {sm.get_color_str(ColorRole.BUTTON_BACKGROUND_RECOMMENDED_PRESSED)};
+            }}
+        """)
+
+        self._card.adjustSize()
+        self._position_card()
+        self.update()
+
+    def show_step(
+        self,
+        title: str,
+        description: str,
+        step_label: str,
+        back_label: str,
+        skip_label: str,
+        next_label: str,
+        can_go_back: bool,
+        spotlight_target: QWidget | None,
+    ) -> None:
+        """Display one tour step: its text, its buttons, and its spotlight target."""
+        content = (title, description, step_label, back_label, skip_label, next_label, can_go_back)
+
+        if not self._has_shown_step:
+            self._has_shown_step = True
+            self._apply_content(*content)
+            self._current_target = spotlight_target
+            self._spotlight_rect = self._resolve_spotlight_rect(spotlight_target)
+            self._spotlight_alpha = 0.0 if self._spotlight_rect.isEmpty() else 1.0
+            self._card.adjustSize()
+            self._position_card()
+            self._set_pulse_active(not self._spotlight_rect.isEmpty())
+            self.update()
+            self._fade_overlay_in()
+            self._next_button.setFocus()
+            return
+
+        self._current_target = spotlight_target
+        self._apply_content(*content)
+        self._card.adjustSize()
+        self._position_card()
+        self._animate_spotlight_to(self._resolve_spotlight_rect(spotlight_target))
+        self.raise_()
+        self._next_button.setFocus()
+
+    def fade_out(self, on_finished: Callable[[], None]) -> None:
+        """Fade the whole overlay out, then invoke on_finished."""
+        self._set_pulse_active(False)
+        self._animate_dim(self._dim_alpha, 0.0, on_finished)
+        self._animate_card_opacity(self._opacity_effect.opacity(), 0.0, _OVERLAY_FADE_DURATION_MS)
+
+    def refresh_layout(self) -> None:
+        """Recompute the spotlight rect for the current target and reposition the card."""
+        self._stop_transition_animations()
+        self._spotlight_rect = self._resolve_spotlight_rect(self._current_target)
+        self._spotlight_alpha = 0.0 if self._spotlight_rect.isEmpty() else 1.0
+        self._card.adjustSize()
+        self._position_card()
+        self._set_pulse_active(not self._spotlight_rect.isEmpty())
+        self.update()
+
+    def _stop_transition_animations(self) -> None:
+        """Stop any in-flight spotlight/card-position transition animations."""
+        for animation in (self._spotlight_animation, self._spotlight_alpha_animation, self._card_position_animation):
+            if animation is not None:
+                animation.stop()
+
+        self._spotlight_animation = None
+        self._spotlight_alpha_animation = None
+        self._card_position_animation = None
+
+    def _fade_overlay_in(self) -> None:
+        """Fade the whole overlay in from fully transparent."""
+        self.raise_()
+        self.show()
+        self._animate_dim(self._dim_alpha, 1.0)
+        self._animate_card_opacity(self._opacity_effect.opacity(), 1.0, _OVERLAY_FADE_DURATION_MS)
+
+    def _animate_dim(self, start: float, end: float, on_finished: Callable[[], None] | None = None) -> None:
+        """Animate the dim background's alpha multiplier (tour open/close only)."""
+        if self._dim_fade_animation is not None:
+            self._dim_fade_animation.stop()
+
+        animation = QVariantAnimation(self)
+        animation.setDuration(_OVERLAY_FADE_DURATION_MS)
+        animation.setEasingCurve(QEasingCurve.Type.InOutQuad)
+        animation.setStartValue(start)
+        animation.setEndValue(end)
+        animation.valueChanged.connect(self._on_dim_alpha_changed)
+        if on_finished is not None:
+            animation.finished.connect(on_finished)
+
+        self._dim_fade_animation = animation
+        animation.start()
+
+    def _on_dim_alpha_changed(self, value: float) -> None:
+        """Advance the dim background's alpha by one animation frame."""
+        self._dim_alpha = value
+        self.update()
+
+    def _animate_card_opacity(
+        self, start: float, end: float, duration: int, on_finished: Callable[[], None] | None = None,
+    ) -> None:
+        """Animate the card's own opacity effect."""
+        if self._card_fade_animation is not None:
+            self._card_fade_animation.stop()
+
+        animation = QPropertyAnimation(self._opacity_effect, b"opacity", self)
+        animation.setDuration(duration)
+        animation.setEasingCurve(QEasingCurve.Type.InOutQuad)
+        animation.setStartValue(start)
+        animation.setEndValue(end)
+        if on_finished is not None:
+            animation.finished.connect(on_finished)
+
+        self._card_fade_animation = animation
+        animation.start()
+
+    def _apply_content(
+        self, title: str, description: str, step_label: str, back_label: str, skip_label: str,
+        next_label: str, can_go_back: bool,
+    ) -> None:
+        """Set the card's text and buttons to one step's content."""
+        self._title_label.setText(title)
+        self._description_label.setText(description)
+        self._step_label.setText(step_label)
+        self._skip_button.setText(skip_label)
+        self._back_button.setText(back_label)
+        self._back_button.setVisible(can_go_back)
+        self._next_button.setText(next_label)
+
+    def _animate_spotlight_to(self, new_rect: QRect) -> None:
+        """
+        Transition the spotlight (and the card following it) to new_rect.
+
+        When both the old and new spotlights are real widgets, the ring glides
+        directly between them.  When one side has no spotlight at all (e.g. the
+        centred Welcome step), there is no rect to glide from/to, so instead the
+        ring cross-fades in or out in place while the card's position is animated
+        on its own between its current spot and its new one.
+        """
+        old_rect = self._spotlight_rect
+        self._stop_transition_animations()
+
+        card_size = self._card.size()
+        old_card_pos = self._card.pos()
+        new_card_pos = self._compute_card_position(new_rect, card_size)
+
+        if not old_rect.isEmpty() and not new_rect.isEmpty():
+            self._spotlight_alpha = 1.0
+            animation = QVariantAnimation(self)
+            animation.setDuration(_SPOTLIGHT_GLIDE_DURATION_MS)
+            animation.setEasingCurve(QEasingCurve.Type.OutCubic)
+            animation.setStartValue(old_rect)
+            animation.setEndValue(new_rect)
+            animation.valueChanged.connect(self._on_spotlight_rect_animated)
+            self._spotlight_animation = animation
+            animation.start()
+            return
+
+        if old_rect.isEmpty() and new_rect.isEmpty():
+            self._spotlight_rect = new_rect
+            self._position_card()
+            self._set_pulse_active(False)
+            self.update()
+            return
+
+        if new_rect.isEmpty():
+            # Fade the ring out in place (nothing to glide it towards) while the card leaves.
+            self._spotlight_rect = old_rect
+            self._animate_spotlight_alpha(1.0, 0.0, on_finished=lambda: self._finish_spotlight_fade(new_rect))
+
+        else:
+            # Show the ring at its new spot immediately and fade it in while the card arrives.
+            self._spotlight_rect = new_rect
+            self._animate_spotlight_alpha(0.0, 1.0)
+
+        self._set_pulse_active(not new_rect.isEmpty())
+        self._animate_card_position(old_card_pos, new_card_pos)
+
+    def _finish_spotlight_fade(self, final_rect: QRect) -> None:
+        """Settle the spotlight rect once a fade-out transition has finished."""
+        self._spotlight_rect = final_rect
+        self.update()
+
+    def _on_spotlight_rect_animated(self, value: QRect) -> None:
+        """Advance the spotlight rect by one animation frame, keeping the card in step."""
+        self._spotlight_rect = value
+        self._position_card()
+        self.update()
+
+    def _animate_spotlight_alpha(self, start: float, end: float, on_finished: Callable[[], None] | None = None) -> None:
+        """Cross-fade the spotlight ring/hole in or out in place."""
+        animation = QVariantAnimation(self)
+        animation.setDuration(_SPOTLIGHT_GLIDE_DURATION_MS)
+        animation.setEasingCurve(QEasingCurve.Type.InOutQuad)
+        animation.setStartValue(start)
+        animation.setEndValue(end)
+        animation.valueChanged.connect(self._on_spotlight_alpha_animated)
+        if on_finished is not None:
+            animation.finished.connect(on_finished)
+
+        self._spotlight_alpha_animation = animation
+        animation.start()
+
+    def _on_spotlight_alpha_animated(self, value: float) -> None:
+        """Advance the spotlight ring/hole's cross-fade by one animation frame."""
+        self._spotlight_alpha = value
+        self.update()
+
+    def _animate_card_position(self, start: QPoint, end: QPoint) -> None:
+        """Glide the card between two positions, independently of the spotlight ring."""
+        animation = QVariantAnimation(self)
+        animation.setDuration(_SPOTLIGHT_GLIDE_DURATION_MS)
+        animation.setEasingCurve(QEasingCurve.Type.OutCubic)
+        animation.setStartValue(start)
+        animation.setEndValue(end)
+        animation.valueChanged.connect(self._on_card_position_animated)
+        self._card_position_animation = animation
+        animation.start()
+
+    def _on_card_position_animated(self, value: QPoint) -> None:
+        """Advance the card's position by one animation frame."""
+        self._card.move(value)
+
+    def _set_pulse_active(self, active: bool) -> None:
+        """Start, resume, or pause the idle pulsing glow on the spotlight ring."""
+        if active:
+            if self._pulse_animation.state() == QAbstractAnimation.State.Paused:
+                self._pulse_animation.resume()
+
+            elif self._pulse_animation.state() != QAbstractAnimation.State.Running:
+                self._pulse_animation.start()
+
+        else:
+            if self._pulse_animation.state() == QAbstractAnimation.State.Running:
+                self._pulse_animation.pause()
+
+    def _on_pulse_value_changed(self, value: float) -> None:
+        """Advance the spotlight ring's pulse glow by one animation frame."""
+        self._pulse_alpha = value
+        if not self._spotlight_rect.isEmpty():
+            self.update()
+
+    def _resolve_spotlight_rect(self, target: QWidget | None) -> QRect:
+        """Return target's geometry in this overlay's coordinate space, or an empty rect."""
+        if target is None:
+            return QRect()
+
+        parent = self.parentWidget()
+        if parent is None:
+            return QRect()
+
+        try:
+            if not target.isVisible():
+                return QRect()
+
+            _scroll_target_into_view(target)
+            top_left = target.mapTo(parent, QPoint(0, 0))
+            return QRect(top_left, target.size())
+
+        except RuntimeError:
+            # The target's underlying C++ object has already been destroyed.
+            return QRect()
+
+    def _position_card(self) -> None:
+        """Position the coach-mark card near the spotlight, or centred if there is none."""
+        # The card has a fixed width (see apply_style), so its actual, already-clamped
+        # size must be used here rather than sizeHint(), which ignores that clamp.
+        card_size = self._card.size()
+        pos = self._compute_card_position(self._spotlight_rect, card_size)
+        self._card.setGeometry(QRect(pos, card_size))
+
+    def _compute_card_position(self, spotlight_rect: QRect, card_size: QSize) -> QPoint:
+        """Compute where the card should sit for spotlight_rect, without moving it."""
+        margin = self._style_manager.scale(16)
+        overlay_rect = self.rect()
+
+        if spotlight_rect.isEmpty():
+            x = (overlay_rect.width() - card_size.width()) // 2
+            y = (overlay_rect.height() - card_size.height()) // 2
+            return QPoint(x, y)
+
+        spot = spotlight_rect
+        gap = self._style_manager.scale(12)
+
+        space_below = overlay_rect.bottom() - spot.bottom()
+        space_above = spot.top() - overlay_rect.top()
+        space_right = overlay_rect.right() - spot.right()
+        space_left = spot.left() - overlay_rect.left()
+
+        if space_below >= card_size.height() + gap:
+            x = spot.center().x() - card_size.width() // 2
+            y = spot.bottom() + gap
+
+        elif space_above >= card_size.height() + gap:
+            x = spot.center().x() - card_size.width() // 2
+            y = spot.top() - gap - card_size.height()
+
+        elif space_right >= card_size.width() + gap:
+            x = spot.right() + gap
+            y = spot.center().y() - card_size.height() // 2
+
+        elif space_left >= card_size.width() + gap:
+            x = spot.left() - gap - card_size.width()
+            y = spot.center().y() - card_size.height() // 2
+
+        else:
+            x = spot.center().x() - card_size.width() // 2
+            y = spot.center().y() - card_size.height() // 2
+
+        x = max(margin, min(x, overlay_rect.width() - card_size.width() - margin))
+        y = max(margin, min(y, overlay_rect.height() - card_size.height() - margin))
+        return QPoint(x, y)
+
+    def paintEvent(self, _event: QPaintEvent) -> None:
+        painter = QPainter(self)
+        painter.setRenderHint(QPainter.RenderHint.Antialiasing)
+
+        dim = QColor(self._style_manager.get_color(ColorRole.BACKGROUND_PRIMARY))
+        dim.setAlpha(int(_DIM_BASE_ALPHA * self._dim_alpha))
+
+        full_path = QPainterPath()
+        full_path.addRect(QRectF(self.rect()))
+
+        if self._spotlight_rect.isEmpty():
+            painter.fillPath(full_path, dim)
+
+        else:
+            radius = self._style_manager.radius("surface")
+            hole_path = QPainterPath()
+            hole_path.addRoundedRect(QRectF(self._spotlight_rect), radius, radius)
+            painter.fillPath(full_path.subtracted(hole_path), dim)
+
+            # When cross-fading in/out (rather than gliding between two real spotlights),
+            # the hole itself fades between fully dimmed and fully clear.
+            if self._spotlight_alpha < 1.0:
+                hole_dim = QColor(dim)
+                hole_dim.setAlpha(int(dim.alpha() * (1.0 - self._spotlight_alpha)))
+                painter.fillPath(hole_path, hole_dim)
+
+            ring_color = QColor(self._style_manager.get_color(ColorRole.BRAND_PRIMARY))
+            ring_color.setAlphaF(self._pulse_alpha * self._dim_alpha * self._spotlight_alpha)
+            pen = QPen(ring_color)
+            pen.setWidthF(2.0)
+            painter.setPen(pen)
+            painter.setBrush(Qt.BrushStyle.NoBrush)
+            painter.drawRoundedRect(QRectF(self._spotlight_rect).adjusted(1, 1, -1, -1), radius, radius)
+
+    def resizeEvent(self, event: QResizeEvent) -> None:
+        super().resizeEvent(event)
+        self.refresh_layout()
+
+    def keyPressEvent(self, event: QKeyEvent) -> None:
+        if event.key() == Qt.Key.Key_Escape:
+            self.skip_requested.emit()
+            return
+
+        if event.key() in (Qt.Key.Key_Return, Qt.Key.Key_Enter, Qt.Key.Key_Right):
+            self.next_requested.emit()
+            return
+
+        if event.key() == Qt.Key.Key_Left and self._back_button.isVisible():
+            self.back_requested.emit()
+            return
+
+        super().keyPressEvent(event)

--- a/src/desktop/tour/tour_step.py
+++ b/src/desktop/tour/tour_step.py
@@ -1,0 +1,27 @@
+"""Definition of a single step of the onboarding product tour."""
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from PySide6.QtWidgets import QWidget
+
+from desktop.language.language_strings import LanguageStrings
+
+if TYPE_CHECKING:
+    from desktop.main_window import MainWindow
+
+
+@dataclass
+class TourStep:
+    """
+    Describes one step of the onboarding tour.
+
+    resolve_target is called each time the step is shown and returns the
+    widget to spotlight, or None to show the step as a centred card with
+    no spotlight (used for the welcome step, and as a graceful fallback
+    when the intended target cannot be found).
+    """
+    title: Callable[[LanguageStrings], str]
+    description: Callable[[LanguageStrings], str]
+    resolve_target: Callable[["MainWindow"], QWidget | None]

--- a/src/desktop/tour/tour_steps.py
+++ b/src/desktop/tour/tour_steps.py
@@ -1,0 +1,102 @@
+"""Centrally configurable list of onboarding tour steps for Humbug."""
+
+from typing import TYPE_CHECKING
+
+from PySide6.QtWidgets import QWidget
+
+from desktop.conversation_tab.conversation_tab import ConversationTab
+from desktop.tour.tour_step import TourStep
+
+if TYPE_CHECKING:
+    from desktop.main_window import MainWindow
+
+
+def _resolve_start_here(main_window: "MainWindow") -> QWidget | None:
+    """Spotlight the mindspace picker button, the first thing a new user should open."""
+    return main_window.sidebar_manager().header_widget()
+
+
+def _resolve_open_conversation(main_window: "MainWindow") -> QWidget | None:
+    """Spotlight the Conversations rail button, used to open or start a conversation."""
+    return main_window.sidebar_manager().panel_button("conversations")
+
+
+def _resolve_workspace(main_window: "MainWindow") -> QWidget | None:
+    """Spotlight the tab area where conversations and other tabs are shown."""
+    return main_window.tab_manager()
+
+
+def _resolve_key_action(main_window: "MainWindow") -> QWidget | None:
+    """Spotlight the message submit button, falling back to the workspace if no conversation is open."""
+    tab = main_window.tab_manager().get_current_tab()
+    if isinstance(tab, ConversationTab):
+        submit_button = tab.conversation_widget().submit_button()
+        if submit_button is not None:
+            return submit_button
+
+    return main_window.tab_manager()
+
+
+def _resolve_output(main_window: "MainWindow") -> QWidget | None:
+    """Spotlight the conversation history area, falling back to the workspace if no conversation is open."""
+    tab = main_window.tab_manager().get_current_tab()
+    if isinstance(tab, ConversationTab):
+        return tab.conversation_widget().scroll_area()
+
+    return main_window.tab_manager()
+
+
+def _resolve_navigation(main_window: "MainWindow") -> QWidget | None:
+    """Spotlight the sidebar icon rail used to switch between panels."""
+    return main_window.sidebar_manager().rail_widget()
+
+
+def _resolve_help(main_window: "MainWindow") -> QWidget | None:
+    """Spotlight the settings button, mentioned alongside the tour replay entry point."""
+    return main_window.sidebar_manager().settings_button()
+
+
+def build_tour_steps() -> list[TourStep]:
+    """Build the ordered list of onboarding tour steps."""
+    return [
+        TourStep(
+            title=lambda strings: strings.tour_welcome_title,
+            description=lambda strings: strings.tour_welcome_description,
+            resolve_target=lambda _main_window: None,
+        ),
+        TourStep(
+            title=lambda strings: strings.tour_start_here_title,
+            description=lambda strings: strings.tour_start_here_description,
+            resolve_target=_resolve_start_here,
+        ),
+        TourStep(
+            title=lambda strings: strings.tour_open_conversation_title,
+            description=lambda strings: strings.tour_open_conversation_description,
+            resolve_target=_resolve_open_conversation,
+        ),
+        TourStep(
+            title=lambda strings: strings.tour_workspace_title,
+            description=lambda strings: strings.tour_workspace_description,
+            resolve_target=_resolve_workspace,
+        ),
+        TourStep(
+            title=lambda strings: strings.tour_key_action_title,
+            description=lambda strings: strings.tour_key_action_description,
+            resolve_target=_resolve_key_action,
+        ),
+        TourStep(
+            title=lambda strings: strings.tour_output_title,
+            description=lambda strings: strings.tour_output_description,
+            resolve_target=_resolve_output,
+        ),
+        TourStep(
+            title=lambda strings: strings.tour_navigation_title,
+            description=lambda strings: strings.tour_navigation_description,
+            resolve_target=_resolve_navigation,
+        ),
+        TourStep(
+            title=lambda strings: strings.tour_help_title,
+            description=lambda strings: strings.tour_help_description,
+            resolve_target=_resolve_help,
+        ),
+    ]

--- a/src/desktop/tour/tour_steps.py
+++ b/src/desktop/tour/tour_steps.py
@@ -1,5 +1,6 @@
 """Centrally configurable list of onboarding tour steps for Humbug."""
 
+import sys
 from typing import TYPE_CHECKING
 
 from PySide6.QtWidgets import QWidget
@@ -9,6 +10,14 @@ from desktop.tour.tour_step import TourStep
 
 if TYPE_CHECKING:
     from desktop.main_window import MainWindow
+
+
+def _submit_shortcut_text() -> str:
+    """Return the platform-appropriate keyboard shortcut for submitting a message."""
+    if sys.platform == "darwin":
+        return "⌘ Enter"
+
+    return "Ctrl+Enter"
 
 
 def _resolve_start_here(main_window: "MainWindow") -> QWidget | None:
@@ -81,7 +90,7 @@ def build_tour_steps() -> list[TourStep]:
         ),
         TourStep(
             title=lambda strings: strings.tour_key_action_title,
-            description=lambda strings: strings.tour_key_action_description,
+            description=lambda strings: strings.tour_key_action_description.format(_submit_shortcut_text()),
             resolve_target=_resolve_key_action,
         ),
         TourStep(

--- a/src/desktop/trash_sidebar/trash_sidebar.py
+++ b/src/desktop/trash_sidebar/trash_sidebar.py
@@ -49,16 +49,16 @@ class TrashSidebar(SidebarBase):
         self._mindspace_path = ""
         self._empty_state_spacer: QSpacerItem | None = None
 
-        layout = QVBoxLayout(self)
-        layout.setContentsMargins(0, 0, 0, 0)
-        layout.setSpacing(0)
+        self._layout = QVBoxLayout(self)
+        self._layout.setContentsMargins(0, 0, 0, 0)
+        self._layout.setSpacing(0)
 
         self._header = SidebarSectionHeader(self._language_manager.strings().trash, self)
-        layout.addWidget(self._header)
+        self._layout.addWidget(self._header)
 
         self._status_label = QLabel(self)
         self._status_label.setObjectName("_status_label")
-        layout.addWidget(self._status_label)
+        self._layout.addWidget(self._status_label)
 
         self._tree = QTreeWidget(self)
         self._tree.setObjectName("TrashSidebarTree")
@@ -69,7 +69,7 @@ class TrashSidebar(SidebarBase):
         self._tree.setRootIsDecorated(False)
         self._tree.setContextMenuPolicy(Qt.ContextMenuPolicy.CustomContextMenu)
         self._tree.customContextMenuRequested.connect(self._show_context_menu)
-        layout.addWidget(self._tree)
+        self._layout.addWidget(self._tree)
 
         self._on_language_changed()
 
@@ -95,7 +95,7 @@ class TrashSidebar(SidebarBase):
         self._status_label.hide()
         self._tree.show()
         if self._empty_state_spacer is not None:
-            self.layout().removeItem(self._empty_state_spacer)
+            self._layout.removeItem(self._empty_state_spacer)
             self._empty_state_spacer = None
 
         for entry in entries:
@@ -110,7 +110,7 @@ class TrashSidebar(SidebarBase):
             self._empty_state_spacer = QSpacerItem(
                 0, 0, QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Expanding
             )
-            self.layout().addItem(self._empty_state_spacer)
+            self._layout.addItem(self._empty_state_spacer)
 
     def _build_item(self, entry: TrashEntry) -> QTreeWidgetItem:
         """Build a single row for a trash entry."""

--- a/src/desktop/user/onboarding_tour_status.py
+++ b/src/desktop/user/onboarding_tour_status.py
@@ -1,0 +1,10 @@
+"""Onboarding product tour status enumeration."""
+
+from enum import Enum
+
+
+class OnboardingTourStatus(Enum):
+    """Enumeration of the states the onboarding product tour can be in."""
+    NOT_STARTED = "not_started"
+    SKIPPED = "skipped"
+    COMPLETED = "completed"

--- a/src/desktop/user/user_settings.py
+++ b/src/desktop/user/user_settings.py
@@ -11,6 +11,7 @@ from filesystem_ai_tool.filesystem_access_settings import FilesystemAccessSettin
 
 from desktop.language.language_code import LanguageCode
 from desktop.color_theme import ColorTheme
+from desktop.user.onboarding_tour_status import OnboardingTourStatus
 from desktop.user.user_file_sort_order import UserFileSortOrder
 
 
@@ -36,6 +37,8 @@ class UserSettings:
     check_for_updates: bool = True
     external_file_allowlist: list[str] = field(default_factory=list)
     external_file_denylist: list[str] = field(default_factory=list)
+    onboarding_tour_status: OnboardingTourStatus = OnboardingTourStatus.NOT_STARTED
+    onboarding_tour_version: int = 0
 
     @classmethod
     def create_default(cls) -> "UserSettings":
@@ -61,7 +64,9 @@ class UserSettings:
             allow_external_file_access=True,
             check_for_updates=True,
             external_file_allowlist=FilesystemAccessSettings.get_default_allowlist(),
-            external_file_denylist=FilesystemAccessSettings.get_default_denylist()
+            external_file_denylist=FilesystemAccessSettings.get_default_denylist(),
+            onboarding_tour_status=OnboardingTourStatus.NOT_STARTED,
+            onboarding_tour_version=0
         )
 
     @staticmethod
@@ -394,6 +399,37 @@ class UserSettings:
                 path
             )
 
+        # Load onboarding tour state with validation
+        tour_status_str = data.get("onboardingTourStatus", "NOT_STARTED")
+        if not isinstance(tour_status_str, str):
+            cls._logger.warning(
+                "Invalid onboardingTourStatus type in %s: expected str, got %s. Using default.",
+                path, type(tour_status_str).__name__
+            )
+            settings.onboarding_tour_status = OnboardingTourStatus.NOT_STARTED
+
+        else:
+            try:
+                settings.onboarding_tour_status = OnboardingTourStatus[tour_status_str]
+
+            except (KeyError, ValueError):
+                cls._logger.warning(
+                    "Invalid onboardingTourStatus '%s' in %s. Using default (NOT_STARTED).",
+                    tour_status_str, path
+                )
+                settings.onboarding_tour_status = OnboardingTourStatus.NOT_STARTED
+
+        tour_version = data.get("onboardingTourVersion", 0)
+        if not isinstance(tour_version, int):
+            cls._logger.warning(
+                "Invalid onboardingTourVersion type in %s: expected int, got %s. Using default.",
+                path, type(tour_version).__name__
+            )
+            settings.onboarding_tour_version = 0
+
+        else:
+            settings.onboarding_tour_version = tour_version
+
         # Load the name of the active saved custom theme (None means the live custom set)
         active_custom_theme = data.get("activeCustomThemeName", None)
         if active_custom_theme is None or (
@@ -537,7 +573,9 @@ class UserSettings:
             "checkForUpdates": self.check_for_updates,
             "allowExternalFileAccess": self.allow_external_file_access,
             "externalFileAllowlist": self.external_file_allowlist,
-            "externalFileDenylist": self.external_file_denylist
+            "externalFileDenylist": self.external_file_denylist,
+            "onboardingTourStatus": self.onboarding_tour_status.name,
+            "onboardingTourVersion": self.onboarding_tour_version
         }
 
         with open(path, 'w', encoding='utf-8') as f:

--- a/tests/desktop/test_tour_controller.py
+++ b/tests/desktop/test_tour_controller.py
@@ -1,0 +1,130 @@
+"""Tests for the onboarding tour controller (step advancement and persistence)."""
+# pylint: disable=protected-access, missing-class-docstring, missing-function-docstring
+# pylint: disable=redefined-outer-name, unused-argument
+
+import pytest
+from PySide6.QtWidgets import QMainWindow, QWidget
+
+from desktop.tour.tour_controller import CURRENT_TOUR_VERSION, TourController
+from desktop.tour.tour_step import TourStep
+from desktop.user.onboarding_tour_status import OnboardingTourStatus
+from desktop.user.user_settings import UserSettings
+
+
+class _FakeUserManager:
+    """Stand-in for the UserManager singleton that never touches disk."""
+
+    def __init__(self) -> None:
+        self._settings = UserSettings.create_default()
+        self.update_calls: list[UserSettings] = []
+
+    def settings(self) -> UserSettings:
+        return self._settings
+
+    def update_settings(self, settings: UserSettings) -> None:
+        self.update_calls.append(settings)
+        self._settings = settings
+
+
+def make_steps(count=3):
+    return [
+        TourStep(
+            title=lambda strings, i=i: f"title {i}",
+            description=lambda strings, i=i: f"description {i}",
+            resolve_target=lambda _main_window: None,
+        )
+        for i in range(count)
+    ]
+
+
+@pytest.fixture
+def fake_user_manager(monkeypatch):
+    fake = _FakeUserManager()
+    monkeypatch.setattr("desktop.tour.tour_controller.UserManager", lambda: fake)
+    return fake
+
+
+@pytest.fixture
+def main_window(qapp):
+    window = QMainWindow()
+    window.setCentralWidget(QWidget())
+    window.resize(800, 600)
+    yield window
+    window.deleteLater()
+    qapp.processEvents()
+
+
+class TestStartAndAdvance:
+    def test_start_shows_first_step(self, fake_user_manager, main_window):
+        controller = TourController(main_window, steps=make_steps())
+        controller.start()
+        assert controller._overlay is not None
+        assert controller._overlay._title_label.text() == "title 0"
+
+    def test_next_advances_step(self, fake_user_manager, main_window, settle):
+        controller = TourController(main_window, steps=make_steps())
+        controller.start()
+        controller._on_next()
+        settle(800)
+        assert controller._overlay._title_label.text() == "title 1"
+
+    def test_back_returns_to_previous_step(self, fake_user_manager, main_window, settle):
+        controller = TourController(main_window, steps=make_steps())
+        controller.start()
+        controller._on_next()
+        settle(800)
+        controller._on_back()
+        settle(800)
+        assert controller._overlay._title_label.text() == "title 0"
+
+    def test_back_on_first_step_is_a_no_op(self, fake_user_manager, main_window):
+        controller = TourController(main_window, steps=make_steps())
+        controller.start()
+        controller._on_back()
+        assert controller._overlay._title_label.text() == "title 0"
+
+    def test_next_on_last_step_completes_and_removes_overlay(self, fake_user_manager, main_window):
+        controller = TourController(main_window, steps=make_steps(count=2))
+        controller.start()
+        controller._on_next()
+        controller._on_next()
+        assert controller._overlay is None
+        assert fake_user_manager.settings().onboarding_tour_status == OnboardingTourStatus.COMPLETED
+        assert fake_user_manager.settings().onboarding_tour_version == CURRENT_TOUR_VERSION
+
+
+class TestSkip:
+    def test_skip_removes_overlay_and_persists_skipped_status(self, fake_user_manager, main_window):
+        controller = TourController(main_window, steps=make_steps())
+        controller.start()
+        controller._on_skip()
+        assert controller._overlay is None
+        assert fake_user_manager.settings().onboarding_tour_status == OnboardingTourStatus.SKIPPED
+        assert fake_user_manager.settings().onboarding_tour_version == CURRENT_TOUR_VERSION
+
+
+class TestAutoStartOnLaunch:
+    def test_starts_when_never_seen(self, fake_user_manager, main_window):
+        fake_user_manager.settings().onboarding_tour_version = 0
+        controller = TourController(main_window, steps=make_steps())
+        controller.maybe_start_on_launch()
+        assert controller._overlay is not None
+
+    def test_does_not_start_when_already_seen(self, fake_user_manager, main_window):
+        fake_user_manager.settings().onboarding_tour_version = CURRENT_TOUR_VERSION
+        controller = TourController(main_window, steps=make_steps())
+        controller.maybe_start_on_launch()
+        assert controller._overlay is None
+
+
+class TestRestart:
+    def test_take_a_tour_restarts_from_first_step(self, fake_user_manager, main_window):
+        controller = TourController(main_window, steps=make_steps())
+        controller.start()
+        controller._on_next()
+        controller._on_skip()
+        assert controller._overlay is None
+
+        controller.start()
+        assert controller._overlay is not None
+        assert controller._overlay._title_label.text() == "title 0"

--- a/tests/desktop/test_tour_overlay.py
+++ b/tests/desktop/test_tour_overlay.py
@@ -1,0 +1,278 @@
+"""Tests for the onboarding tour overlay (dimmed spotlight + coach-mark card)."""
+# pylint: disable=protected-access, missing-class-docstring, missing-function-docstring
+
+from PySide6.QtCore import QAbstractAnimation, QEvent, QPoint, QPointF, Qt
+from PySide6.QtGui import QKeyEvent, QMouseEvent
+from PySide6.QtWidgets import QPushButton
+
+from desktop.tour.tour_overlay import TourOverlay
+
+
+def make_overlay(host):
+    overlay = TourOverlay(host)
+    overlay.setGeometry(host.rect())
+    return overlay
+
+
+def show_step(overlay, can_go_back=False, spotlight_target=None):
+    overlay.show_step(
+        title="Title",
+        description="Description",
+        step_label="Step 1 of 7",
+        back_label="Back",
+        skip_label="Skip Tour",
+        next_label="Next",
+        can_go_back=can_go_back,
+        spotlight_target=spotlight_target,
+    )
+
+
+def press_key(qapp, widget, key):
+    qapp.sendEvent(widget, QKeyEvent(QEvent.Type.KeyPress, key, Qt.KeyboardModifier.NoModifier))
+
+
+class TestContent:
+    def test_show_step_sets_text(self, host):
+        overlay = make_overlay(host)
+        show_step(overlay)
+        assert overlay._title_label.text() == "Title"
+        assert overlay._description_label.text() == "Description"
+        assert overlay._step_label.text() == "Step 1 of 7"
+
+    def test_back_button_hidden_on_first_step(self, host):
+        overlay = make_overlay(host)
+        show_step(overlay, can_go_back=False)
+        assert not overlay._back_button.isVisible()
+
+    def test_back_button_shown_when_not_first_step(self, qapp, host):
+        host.show()
+        overlay = make_overlay(host)
+        overlay.show()
+        qapp.processEvents()
+        show_step(overlay, can_go_back=True)
+        assert overlay._back_button.isVisible()
+
+
+class TestKeyboardNavigation:
+    def test_escape_skips(self, qapp, host):
+        overlay = make_overlay(host)
+        show_step(overlay)
+        skipped = []
+        overlay.skip_requested.connect(lambda: skipped.append(True))
+        press_key(qapp, overlay, Qt.Key.Key_Escape)
+        assert skipped
+
+    def test_right_arrow_advances(self, qapp, host):
+        overlay = make_overlay(host)
+        show_step(overlay)
+        advanced = []
+        overlay.next_requested.connect(lambda: advanced.append(True))
+        press_key(qapp, overlay, Qt.Key.Key_Right)
+        assert advanced
+
+    def test_left_arrow_goes_back_when_available(self, qapp, host):
+        host.show()
+        overlay = make_overlay(host)
+        overlay.show()
+        qapp.processEvents()
+        show_step(overlay, can_go_back=True)
+        went_back = []
+        overlay.back_requested.connect(lambda: went_back.append(True))
+        press_key(qapp, overlay, Qt.Key.Key_Left)
+        assert went_back
+
+    def test_left_arrow_ignored_on_first_step(self, qapp, host):
+        overlay = make_overlay(host)
+        show_step(overlay, can_go_back=False)
+        went_back = []
+        overlay.back_requested.connect(lambda: went_back.append(True))
+        press_key(qapp, overlay, Qt.Key.Key_Left)
+        assert not went_back
+
+
+class TestMouseHandling:
+    def test_click_on_background_does_not_skip(self, qapp, host):
+        # Skip Tour is the only way to dismiss the tour early; a stray click on
+        # the dimmed background must not close it.
+        overlay = make_overlay(host)
+        show_step(overlay)
+        skipped = []
+        overlay.skip_requested.connect(lambda: skipped.append(True))
+        pos = QPoint(5, 5)
+        event = QMouseEvent(
+            QEvent.Type.MouseButtonPress, QPointF(pos), QPointF(pos), QPointF(pos),
+            Qt.MouseButton.LeftButton, Qt.MouseButton.LeftButton, Qt.KeyboardModifier.NoModifier,
+        )
+        qapp.sendEvent(overlay, event)
+        assert not skipped
+
+
+class TestSpotlightResolution:
+    def test_none_target_gives_empty_rect(self, host):
+        overlay = make_overlay(host)
+        show_step(overlay, spotlight_target=None)
+        assert overlay._spotlight_rect.isEmpty()
+
+    def test_invisible_target_gives_empty_rect(self, host):
+        overlay = make_overlay(host)
+        target = QPushButton(host)
+        target.hide()
+        show_step(overlay, spotlight_target=target)
+        assert overlay._spotlight_rect.isEmpty()
+
+    def test_visible_target_gives_matching_rect(self, qapp, host):
+        host.show()
+        overlay = make_overlay(host)
+        target = QPushButton(host)
+        target.setGeometry(30, 40, 100, 20)
+        target.show()
+        qapp.processEvents()
+        show_step(overlay, spotlight_target=target)
+        assert overlay._spotlight_rect == target.geometry()
+
+    def test_card_centred_when_no_spotlight(self, host):
+        overlay = make_overlay(host)
+        show_step(overlay, spotlight_target=None)
+        card_rect = overlay._card.geometry()
+        assert abs(card_rect.center().x() - host.rect().center().x()) <= 1
+        assert abs(card_rect.center().y() - host.rect().center().y()) <= 1
+
+    def test_card_positioned_below_spotlight_when_room_available(self, host):
+        overlay = make_overlay(host)
+        target = QPushButton(host)
+        target.setGeometry(100, 50, 100, 20)
+        target.show()
+        show_step(overlay, spotlight_target=target)
+        assert overlay._card.geometry().top() > target.geometry().bottom()
+
+
+class TestStepTransitionAnimation:
+    def test_content_updates_immediately_not_after_a_delay(self, qapp, host):
+        overlay = make_overlay(host)
+        show_step(overlay)
+        overlay.show_step(
+            title="Title 2", description="Description 2", step_label="Step 2 of 7",
+            back_label="Back", skip_label="Skip Tour", next_label="Next",
+            can_go_back=True, spotlight_target=None,
+        )
+        assert overlay._title_label.text() == "Title 2"
+        assert overlay._description_label.text() == "Description 2"
+        assert overlay._step_label.text() == "Step 2 of 7"
+
+    def test_card_stays_fully_opaque_across_a_step_transition(self, qapp, host, settle):
+        overlay = make_overlay(host)
+        show_step(overlay)
+        settle(500)
+        overlay.show_step(
+            title="Title 2", description="Description 2", step_label="Step 2 of 7",
+            back_label="Back", skip_label="Skip Tour", next_label="Next",
+            can_go_back=True, spotlight_target=None,
+        )
+        assert overlay._opacity_effect.opacity() == 1.0
+
+    def test_spotlight_glides_between_two_visible_targets(self, qapp, host, settle):
+        host.show()
+        overlay = make_overlay(host)
+        overlay.show()
+        target_a = QPushButton(host)
+        target_a.setGeometry(30, 40, 100, 20)
+        target_a.show()
+        target_b = QPushButton(host)
+        target_b.setGeometry(300, 200, 100, 20)
+        target_b.show()
+        qapp.processEvents()
+
+        show_step(overlay, spotlight_target=target_a)
+        show_step(overlay, spotlight_target=target_b)
+        assert overlay._spotlight_animation is not None
+
+        settle(800)
+        assert overlay._spotlight_rect == target_b.geometry()
+
+    def test_transition_from_no_spotlight_animates_card_and_ring(self, qapp, host, settle):
+        host.show()
+        overlay = make_overlay(host)
+        overlay.show()
+        target = QPushButton(host)
+        target.setGeometry(30, 40, 100, 20)
+        target.show()
+        qapp.processEvents()
+
+        show_step(overlay, spotlight_target=None)
+        centred_pos = overlay._card.pos()
+
+        show_step(overlay, spotlight_target=target)
+        # The ring appears at its final position immediately (nothing to glide it from)...
+        assert overlay._spotlight_animation is None
+        assert overlay._spotlight_rect == target.geometry()
+        # ...but fades in, and the card animates away from its old (centred) position, rather than jumping.
+        assert overlay._spotlight_alpha_animation is not None
+        assert overlay._card_position_animation is not None
+        assert overlay._card.pos() == centred_pos
+
+        settle(800)
+        assert overlay._spotlight_alpha == 1.0
+        assert overlay._card.pos() != centred_pos
+
+    def test_transition_to_no_spotlight_animates_card_and_ring(self, qapp, host, settle):
+        host.show()
+        overlay = make_overlay(host)
+        overlay.show()
+        target = QPushButton(host)
+        target.setGeometry(30, 40, 100, 20)
+        target.show()
+        qapp.processEvents()
+
+        show_step(overlay, spotlight_target=target)
+        spotlighted_pos = overlay._card.pos()
+
+        show_step(overlay, spotlight_target=None)
+        # The ring stays put (nothing to glide it towards) and fades out in place...
+        assert overlay._spotlight_rect == target.geometry()
+        assert overlay._spotlight_alpha_animation is not None
+        # ...while the card animates towards the centre rather than jumping there.
+        assert overlay._card_position_animation is not None
+        assert overlay._card.pos() == spotlighted_pos
+
+        settle(800)
+        assert overlay._spotlight_alpha == 0.0
+        assert overlay._spotlight_rect.isEmpty()
+        assert overlay._card.pos() != spotlighted_pos
+
+
+class TestOverlayFadeAndPulse:
+    def test_overlay_starts_transparent_and_fades_in(self, qapp, host, settle):
+        overlay = make_overlay(host)
+        assert overlay._dim_alpha == 0.0
+        show_step(overlay)
+        settle(500)
+        assert overlay._dim_alpha == 1.0
+
+    def test_fade_out_calls_back_once_finished(self, qapp, host, settle):
+        overlay = make_overlay(host)
+        show_step(overlay)
+        settle(500)
+
+        finished = []
+        overlay.fade_out(lambda: finished.append(True))
+        assert not finished
+        settle(500)
+        assert finished
+        assert overlay._dim_alpha == 0.0
+
+    def test_pulse_runs_while_spotlight_is_shown(self, qapp, host):
+        host.show()
+        overlay = make_overlay(host)
+        overlay.show()
+        target = QPushButton(host)
+        target.setGeometry(30, 40, 100, 20)
+        target.show()
+        qapp.processEvents()
+
+        show_step(overlay, spotlight_target=target)
+        assert overlay._pulse_animation.state() == QAbstractAnimation.State.Running
+
+    def test_pulse_paused_when_there_is_no_spotlight(self, qapp, host):
+        overlay = make_overlay(host)
+        show_step(overlay, spotlight_target=None)
+        assert overlay._pulse_animation.state() != QAbstractAnimation.State.Running

--- a/tests/desktop/test_user_settings_tour.py
+++ b/tests/desktop/test_user_settings_tour.py
@@ -1,0 +1,65 @@
+"""Tests for onboarding tour state persistence on UserSettings."""
+
+import json
+import os
+import tempfile
+
+from desktop.user.onboarding_tour_status import OnboardingTourStatus
+from desktop.user.user_settings import UserSettings
+
+
+class TestDefaults:
+    def test_default_settings_have_not_started_tour(self):
+        settings = UserSettings.create_default()
+        assert settings.onboarding_tour_status == OnboardingTourStatus.NOT_STARTED
+        assert settings.onboarding_tour_version == 0
+
+
+class TestRoundTrip:
+    def test_completed_status_and_version_survive_save_and_load(self):
+        settings = UserSettings.create_default()
+        settings.onboarding_tour_status = OnboardingTourStatus.COMPLETED
+        settings.onboarding_tour_version = 1
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            path = os.path.join(tmp_dir, "user-settings.json")
+            settings.save(path)
+            loaded = UserSettings.load(path)
+
+        assert loaded.onboarding_tour_status == OnboardingTourStatus.COMPLETED
+        assert loaded.onboarding_tour_version == 1
+
+    def test_skipped_status_survives_save_and_load(self):
+        settings = UserSettings.create_default()
+        settings.onboarding_tour_status = OnboardingTourStatus.SKIPPED
+        settings.onboarding_tour_version = 1
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            path = os.path.join(tmp_dir, "user-settings.json")
+            settings.save(path)
+            loaded = UserSettings.load(path)
+
+        assert loaded.onboarding_tour_status == OnboardingTourStatus.SKIPPED
+
+
+class TestMalformedData:
+    def test_invalid_status_string_falls_back_to_not_started(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            path = os.path.join(tmp_dir, "user-settings.json")
+            with open(path, "w", encoding="utf-8") as f:
+                json.dump({"onboardingTourStatus": "NOT_A_REAL_STATUS"}, f)
+
+            loaded = UserSettings.load(path)
+
+        assert loaded.onboarding_tour_status == OnboardingTourStatus.NOT_STARTED
+
+    def test_missing_fields_fall_back_to_defaults(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            path = os.path.join(tmp_dir, "user-settings.json")
+            with open(path, "w", encoding="utf-8") as f:
+                json.dump({}, f)
+
+            loaded = UserSettings.load(path)
+
+        assert loaded.onboarding_tour_status == OnboardingTourStatus.NOT_STARTED
+        assert loaded.onboarding_tour_version == 0


### PR DESCRIPTION
Adds an 8-step guided tour (desktop/tour/) that spotlights Humbug's key
screens for first-time users — mindspace picker, conversations panel,
workspace, message input, conversation history, sidebar navigation, and
settings — with a dimmed backdrop, animated spotlight glide, and a
coach-mark card.

- Tour state (not_started/skipped/completed, versioned) persists via the
  existing UserSettings/UserManager mechanism, not a new store.
- Replayable anytime from Humbug -> Take a Tour.
- Card content updates immediately on Next/Back; the spotlight ring and
  card position animate independently so transitions stay smooth even
  when a step has no target (e.g. the Welcome step).
- Clicking the dimmed background no longer skips the tour, since Skip
  Tour already covers that.
- Adds tour_step/tour_steps/tour_overlay/tour_controller plus small
  getters on SidebarManager, ConversationTab/Widget/Input, and
  MainWindow so the tour can locate its spotlight targets.
- New strings added in English, French, and Arabic.